### PR TITLE
Crash if no Fallback Bundle

### DIFF
--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -165,6 +165,9 @@ public class HeliumPaywallSdkModule: Module {
         apiKey: config["apiKey"] as? String ?? "",
         heliumPaywallDelegate: useDefaultDelegate ? defaultDelegate : internalDelegate,
         fallbackConfig: HeliumFallbackConfig.withMultipleFallbacks(
+            // As a workaround for required fallback check in iOS, supply empty fallbackPerTrigger
+            // since currently iOS requires some type of fallback but RN does not.
+            fallbackPerTrigger: [:],
             fallbackBundle: fallbackBundleURL,
             useLoadingState: useLoadingState,
             loadingBudget: loadingBudget,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-helium",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Helium paywalls expo sdk",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Current RN/Expo SDKs will _crash_ if no fallback bundle is provided. I missed this in my testing because I have been providing fallback bundle every time.

This isn't a great long-term fix, created
https://linear.app/tryhelium/issue/HEL-2370/come-up-with-better-fallback-requirement-approach-for-wrapper-sdks

Also need to loop in variations of `initialize` call in test cases.