### PR TITLE
Sdk 8 android disable system back support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Expo module SDK for Helium paywalls. Bridges native iOS (Swift) and Android (Kot
 
 Relevant files for bridge changes:
 - `src/index.ts` — JS bridge calls
+- `src/HeliumPaywallSdkModule.ts` — TypeScript declaration of native module interface
 - `src/HeliumPaywallSdk.types.ts` — TypeScript types
 - `ios/HeliumPaywallSdkModule.swift` — iOS native module
 - `android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt` — Android native module

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Expo module SDK for Helium paywalls. Bridges native iOS (Swift) and Android (Kot
 
 ## Key principles
 
-- **Never crash.** This SDK is distributed to apps with millions of users. Prefer defensive error handling (try/catch) over letting exceptions propagate. A swallowed error is always better than a crash.
+- **Never crash the host app.** This SDK is distributed to apps with millions of users. Wrap bridge boundaries and event handlers in try/catch to prevent SDK errors from propagating. For critical flows consider surfacing failures to callers rather than silently swallowing them.
 - **Avoid using "fallback" in code and comments** unless referring to the Helium fallback paywall flow. This term has a specific meaning in this SDK.
 
 ## Key architecture rule
@@ -22,7 +22,7 @@ Relevant files for bridge changes:
 
 ## Packages
 
-- `packages/stripe/` — Helium Stripe integration (iOS-only native module, guards on `Platform.OS`)
+- `packages/stripe/` — Helium Stripe integration
 - `packages/revenuecat/` — RevenueCat integration
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+## Project overview
+
+Expo module SDK for Helium paywalls. Bridges native iOS (Swift) and Android (Kotlin) SDKs to React Native/Expo via TypeScript.
+
+## Key principles
+
+- **Never crash.** This SDK is distributed to apps with millions of users. Prefer defensive error handling (try/catch) over letting exceptions propagate. A swallowed error is always better than a crash.
+- **Avoid using "fallback" in code and comments** unless referring to the Helium fallback paywall flow. This term has a specific meaning in this SDK.
+
+## Key architecture rule
+
+**When modifying the native bridge interface, both iOS and Android native modules MUST be updated.** Expo modules match function arguments positionally — a mismatch causes a runtime crash. Even platform-specific parameters must be declared (and ignored) on the other platform.
+
+Relevant files for bridge changes:
+- `src/index.ts` — JS bridge calls
+- `src/HeliumPaywallSdk.types.ts` — TypeScript types
+- `ios/HeliumPaywallSdkModule.swift` — iOS native module
+- `android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt` — Android native module
+
+## Packages
+
+- `packages/stripe/` — Helium Stripe integration (iOS-only native module, guards on `Platform.OS`)
+- `packages/revenuecat/` — RevenueCat integration
+
+## Commands
+
+See `scripts` in `package.json` for available commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Expo module SDK for Helium paywalls. Bridges native iOS (Swift) and Android (Kot
 
 ## Key principles
 
-- **Never crash the host app.** This SDK is distributed to apps with millions of users. Wrap bridge boundaries and event handlers in try/catch to prevent SDK errors from propagating. For critical flows consider surfacing failures to callers rather than silently swallowing them.
+- **Never crash the host app.** This SDK is distributed to apps with millions of users. Wrap bridge boundaries and event handlers in try/catch to prevent SDK errors from propagating. For critical flows consider logging and/or surfacing failures to callers rather than silently swallowing them.
 - **Avoid using "fallback" in code and comments** unless referring to the Helium fallback paywall flow. This term has a specific meaning in this SDK.
 
 ## Key architecture rule

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -315,7 +315,7 @@ class HeliumPaywallSdkModule : Module() {
     }
 
     // Present a paywall with the given trigger
-    Function("presentUpsell") { trigger: String, customPaywallTraits: Map<String, Any?>?, dontShowIfAlreadyEntitled: Boolean? ->
+    Function("presentUpsell") { trigger: String, customPaywallTraits: Map<String, Any?>?, dontShowIfAlreadyEntitled: Boolean?, disableSystemBackNavigation: Boolean? ->
       NativeModuleManager.currentModule = this@HeliumPaywallSdkModule // extra redundancy to update to latest live module
 
       // Convert custom paywall traits
@@ -338,7 +338,8 @@ class HeliumPaywallSdkModule : Module() {
         config = PaywallPresentationConfig(
           fromActivityContext = activity,
           customPaywallTraits = convertedTraits,
-          dontShowIfAlreadyEntitled = dontShowIfAlreadyEntitled ?: false
+          dontShowIfAlreadyEntitled = dontShowIfAlreadyEntitled ?: false,
+          disableSystemBackNavigation = disableSystemBackNavigation ?: false
         ),
         onEntitled = {
           NativeModuleManager.safeSendEvent(

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -227,7 +227,7 @@ public class HeliumPaywallSdkModule: Module {
       continuation.resume(returning: success)
     }
 
-    Function("presentUpsell") { (trigger: String, customPaywallTraits: [String: Any]?, dontShowIfAlreadyEntitled: Bool?) in
+    Function("presentUpsell") { (trigger: String, customPaywallTraits: [String: Any]?, dontShowIfAlreadyEntitled: Bool?, _disableSystemBackNavigation: Bool?) in
         NativeModuleManager.shared.currentModule = self // extra redundancy to update to latest live module
         Helium.shared.presentPaywall(
             trigger: trigger,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-helium",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Helium paywalls expo sdk",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -211,6 +211,8 @@ export type PresentUpsellParams = {
    * This is uncommon, but best practice to handle it just in case.
    * See https://docs.tryhelium.com/guides/fallback-bundle */
   onPaywallUnavailable?: () => void;
+  /** Optional. Android only. If true, disables the system back button/gesture while the paywall is displayed. Defaults to false. */
+  androidDisableSystemBackNavigation?: boolean;
 };
 
 export interface PaywallInfo {

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -202,6 +202,8 @@ export type PresentUpsellParams = {
   customPaywallTraits?: Record<string, any>;
   /** Optional. If true, the paywall will not be shown if the user already has an entitlement for a product in the paywall. */
   dontShowIfAlreadyEntitled?: boolean;
+  /** Optional. Android only. If true, disables the system back button/gesture while the paywall is displayed. Defaults to false. */
+  androidDisableSystemBackNavigation?: boolean;
   /** Optional. Called upon purchase success or purchase restore.
    * If you set `dontShowIfAlreadyEntitled` to true, this handler will also be called when paywall not shown
    * to users who already have entitlement for a product in the paywall.
@@ -211,8 +213,6 @@ export type PresentUpsellParams = {
    * This is uncommon, but best practice to handle it just in case.
    * See https://docs.tryhelium.com/guides/fallback-bundle */
   onPaywallUnavailable?: () => void;
-  /** Optional. Android only. If true, disables the system back button/gesture while the paywall is displayed. Defaults to false. */
-  androidDisableSystemBackNavigation?: boolean;
 };
 
 export interface PaywallInfo {

--- a/src/HeliumPaywallSdkModule.ts
+++ b/src/HeliumPaywallSdkModule.ts
@@ -32,6 +32,7 @@ declare class HeliumPaywallSdkModule extends NativeModule<HeliumPaywallSdkModule
     triggerName: string,
     customPaywallTraits?: Record<string, any>,
     dontShowIfAlreadyEntitled?: boolean,
+    androidDisableSystemBackNavigation?: boolean,
   ): void;
 
   hideUpsell(): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,12 +239,13 @@ export const presentUpsell = ({
                                 dontShowIfAlreadyEntitled,
                                 onEntitled,
                                 onPaywallUnavailable,
+                                androidDisableSystemBackNavigation,
                               }: PresentUpsellParams) => {
   try {
     paywallEventHandlers = eventHandlers;
     presentOnPaywallUnavailable = onPaywallUnavailable;
     presentOnEntitled = onEntitled;
-    HeliumPaywallSdkModule.presentUpsell(triggerName, convertBooleansToMarkers(customPaywallTraits), dontShowIfAlreadyEntitled);
+    HeliumPaywallSdkModule.presentUpsell(triggerName, convertBooleansToMarkers(customPaywallTraits), dontShowIfAlreadyEntitled, androidDisableSystemBackNavigation);
   } catch (error) {
     console.log('[Helium] presentUpsell error', error);
     paywallEventHandlers = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,9 +237,9 @@ export const presentUpsell = ({
                                 eventHandlers,
                                 customPaywallTraits,
                                 dontShowIfAlreadyEntitled,
+                                androidDisableSystemBackNavigation,
                                 onEntitled,
                                 onPaywallUnavailable,
-                                androidDisableSystemBackNavigation,
                               }: PresentUpsellParams) => {
   try {
     paywallEventHandlers = eventHandlers;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the cross-platform Expo native bridge signature for `presentUpsell`, which can cause runtime crashes if any consumer or platform is out of sync, and changes Android navigation behavior when the new flag is used.
> 
> **Overview**
> Adds an optional `androidDisableSystemBackNavigation` flag to `presentUpsell`, passing it through the JS/TS bridge and into Android `PaywallPresentationConfig.disableSystemBackNavigation` (defaulting to `false`). iOS updates the `presentUpsell` function signature to keep argument positions aligned but ignores the new parameter.
> 
> Also adds `CLAUDE.md` with bridge/maintenance guidelines and bumps the package version to `3.3.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93a2ad942a73679cf98d1d1606e8642eec6e0c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Android-only flag to disable system back navigation while a paywall is displayed; existing behavior unchanged when omitted. Public API updated to accept this option.

* **Documentation**
  * Added comprehensive SDK documentation covering usage, architecture guidance, and integration commands.

* **Chores**
  * Version bumped to 3.3.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->