### PR TITLE
Str module support and upgrade

### DIFF
--- a/packages/stripe/android/build.gradle
+++ b/packages/stripe/android/build.gradle
@@ -1,0 +1,39 @@
+apply plugin: 'com.android.library'
+
+group = 'expo.modules.stripesdk'
+version = '0.1.0'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 21)
+      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+    }
+  }
+}
+
+android {
+  namespace "expo.modules.stripesdk"
+  defaultConfig {
+    versionCode 1
+    versionName "0.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/packages/stripe/android/src/main/java/expo/modules/stripesdk/HeliumStripeSdkModule.kt
+++ b/packages/stripe/android/src/main/java/expo/modules/stripesdk/HeliumStripeSdkModule.kt
@@ -1,0 +1,27 @@
+package expo.modules.stripesdk
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class HeliumStripeSdkModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("HeliumStripeSdk")
+
+        // No-op implementations — Stripe One Tap is iOS-only for now.
+        // All exported JS functions guard on Platform.OS before calling these.
+
+        Function("initializeStripe") { _: Map<String, Any> -> }
+
+        Function("setUserIdAndSyncStripeIfNeeded") { _: String -> }
+
+        Function("resetStripeEntitlements") { _: Boolean -> }
+
+        AsyncFunction("createStripePortalSession") { _: String ->
+            ""
+        }
+
+        AsyncFunction("hasActiveStripeEntitlement") {
+            false
+        }
+    }
+}

--- a/packages/stripe/expo-module.config.json
+++ b/packages/stripe/expo-module.config.json
@@ -1,6 +1,9 @@
 {
-  "platforms": ["apple"],
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": ["HeliumStripeSdkModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.stripesdk.HeliumStripeSdkModule"]
   }
 }

--- a/packages/stripe/ios/HeliumStripeSdk.podspec
+++ b/packages/stripe/ios/HeliumStripeSdk.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'StripeOneTapPurchase', '1.0.6'
+  s.dependency 'StripeOneTapPurchase', '1.0.7'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-helium-stripe",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Helium Stripe One Tap Purchase add-on for Expo",
   "author": "github.com/appmonetization",
   "license": "MIT",

--- a/packages/stripe/src/HeliumStripeSdkModule.ts
+++ b/packages/stripe/src/HeliumStripeSdkModule.ts
@@ -1,5 +1,4 @@
 import { NativeModule, requireNativeModule } from "expo";
-import { Platform } from "react-native";
 
 declare class HeliumStripeSdkModule extends NativeModule {
   initializeStripe(config: Record<string, any>): void;
@@ -13,9 +12,4 @@ declare class HeliumStripeSdkModule extends NativeModule {
   hasActiveStripeEntitlement(): Promise<boolean>;
 }
 
-// Only resolve the native module on iOS. On Android there is no native
-// HeliumStripeSdk module — all exported functions guard on Platform.OS
-// before touching this reference.
-export default (Platform.OS === "ios"
-  ? requireNativeModule<HeliumStripeSdkModule>("HeliumStripeSdk")
-  : null) as HeliumStripeSdkModule;
+export default requireNativeModule<HeliumStripeSdkModule>("HeliumStripeSdk");

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -11,6 +11,13 @@ export async function initializeWithStripe(config: StripeHeliumConfig): Promise<
         return initialize(config);
     }
 
+    const requiredFields = ['stripePublishableKey', 'merchantIdentifier', 'merchantName', 'managementURL'] as const;
+    const missingFields = requiredFields.filter((field) => !config[field]);
+    if (missingFields.length > 0) {
+        console.warn(`[HeliumStripe] Missing required Stripe config fields: ${missingFields.join(', ')}. Using standard initialization.`);
+        return initialize(config);
+    }
+
     await _setupCore(config);
 
     HeliumStripeSdkModule.initializeStripe({

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -20,15 +20,19 @@ export async function initializeWithStripe(config: StripeHeliumConfig): Promise<
 
     await _setupCore(config);
 
-    HeliumStripeSdkModule.initializeStripe({
-        apiKey: config.apiKey,
-        stripePublishableKey: config.stripePublishableKey,
-        merchantIdentifier: config.merchantIdentifier,
-        merchantName: config.merchantName,
-        managementURL: config.managementURL,
-        countryCode: config.countryCode ?? 'US',
-        currencyCode: config.currencyCode ?? 'USD',
-    });
+    try {
+        HeliumStripeSdkModule.initializeStripe({
+            apiKey: config.apiKey,
+            stripePublishableKey: config.stripePublishableKey,
+            merchantIdentifier: config.merchantIdentifier,
+            merchantName: config.merchantName,
+            managementURL: config.managementURL,
+            countryCode: config.countryCode ?? 'US',
+            currencyCode: config.currencyCode ?? 'USD',
+        });
+    } catch (error) {
+        console.warn('[HeliumStripe] Failed to initialize Stripe One Tap.', error);
+    }
 }
 
 export function setUserIdAndSyncStripeIfNeeded(userId: string): void {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Android native module and Gradle setup plus changes JS native-module resolution, which could affect app startup/module linking across platforms. iOS behavior is slightly safer (validation/try-catch) and dependency bumps are low risk but may change native runtime behavior.
> 
> **Overview**
> Adds Android support to the `expo-helium-stripe` Expo module by introducing an Android library project and a no-op `HeliumStripeSdkModule` implementation, and registering Android in `expo-module.config.json` so `requireNativeModule("HeliumStripeSdk")` can resolve on both platforms.
> 
> On iOS, upgrades `StripeOneTapPurchase` to `1.0.7`, bumps the package version to `1.0.6`, and makes `initializeWithStripe` more defensive by validating required Stripe config fields and wrapping `initializeStripe` in a `try/catch` with warnings and fallback to standard initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61e4fb92719b1f90f6ac0f594cd076d464ad71c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android platform support for Stripe functionality is now available.

* **Improvements**
  * iOS: added validation for required Stripe configuration and graceful handling of initialization errors.
  * Module now consistently exposes the native Stripe integration across platforms.

* **Chores**
  * Updated Stripe dependency versions.
  * Bumped package version to 1.0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->