### PR TITLE
[HEL-4640] | Expo ability to set android consumable product ids

### DIFF
--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -250,6 +250,9 @@ class HeliumPaywallSdkModule : Module() {
         revenueCatAppUserId?.let { Helium.identity.revenueCatAppUserId = it }
 
         Helium.config.heliumPaywallDelegate = delegate
+        @Suppress("UNCHECKED_CAST")
+        val consumableIds = (config["consumableIds"] as? List<String>)?.toSet()
+        consumableIds?.let { Helium.config.consumableIds = it }
         customAPIEndpoint?.let { Helium.config.customApiEndpoint = it }
 
         // Pass fallback JSON to native SDK

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -250,8 +250,11 @@ class HeliumPaywallSdkModule : Module() {
         revenueCatAppUserId?.let { Helium.identity.revenueCatAppUserId = it }
 
         Helium.config.heliumPaywallDelegate = delegate
-        @Suppress("UNCHECKED_CAST")
-        val consumableIds = (config["consumableIds"] as? List<String>)?.toSet()
+        val consumableIds = (config["androidConsumableProductIds"] as? List<*>)
+          ?.mapNotNull { it as? String }
+          ?.map { it.trim() }
++         ?.filter { it.isNotEmpty() }
+          ?.toSet()
         consumableIds?.let { Helium.config.consumableIds = it }
         customAPIEndpoint?.let { Helium.config.customApiEndpoint = it }
 

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -467,8 +467,8 @@ public class HeliumPaywallSdkModule: Module {
       if let fallbackBundleURL {
         Helium.config.customFallbacksURL = fallbackBundleURL
       }
-      if config["consumableIds"] != nil {
-        print("[Helium] consumableIds is only used on Android and will be ignored on iOS.")
+      if config["androidConsumableProductIds"] != nil {
+        print("[Helium] androidConsumableProductIds is only used on Android and will be ignored on iOS.")
       }
 
       if let customAPIEndpoint = config["customAPIEndpoint"] as? String {

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -467,6 +467,10 @@ public class HeliumPaywallSdkModule: Module {
       if let fallbackBundleURL {
         Helium.config.customFallbacksURL = fallbackBundleURL
       }
+      if config["consumableIds"] != nil {
+        print("[Helium] consumableIds is only used on Android and will be ignored on iOS.")
+      }
+
       if let customAPIEndpoint = config["customAPIEndpoint"] as? String {
         Helium.config.customAPIEndpoint = customAPIEndpoint
       }

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -179,6 +179,8 @@ export interface HeliumConfig {
   customAPIEndpoint?: string;
   customUserTraits?: Record<string, any>;
   revenueCatAppUserId?: string;
+  /** Android only. Product IDs that should be treated as consumables. Ignored on iOS. */
+  consumableIds?: string[];
 }
 
 export interface NativeHeliumConfig {
@@ -194,6 +196,7 @@ export interface NativeHeliumConfig {
   environment?: string;
   wrapperSdkVersion?: string;
   delegateType?: string;
+  consumableIds?: string[];
 }
 
 export type PresentUpsellParams = {

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -179,8 +179,13 @@ export interface HeliumConfig {
   customAPIEndpoint?: string;
   customUserTraits?: Record<string, any>;
   revenueCatAppUserId?: string;
-  /** Android only. Product IDs that should be treated as consumables. Ignored on iOS. */
-  consumableIds?: string[];
+  /**
+   * Set consumable product IDs for Android.
+   * These IDs will be used to identify consumable products in the Play Store
+   * and this is only respected if no custom purchaseConfig is supplied.
+   * This is only relevant on Android and is a no-op on other platforms.
+   */
+  androidConsumableProductIds?: string[];
 }
 
 export interface NativeHeliumConfig {
@@ -196,7 +201,7 @@ export interface NativeHeliumConfig {
   environment?: string;
   wrapperSdkVersion?: string;
   delegateType?: string;
-  consumableIds?: string[];
+  androidConsumableProductIds?: string[];
 }
 
 export type PresentUpsellParams = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ const buildNativeConfig = async (config: HeliumConfig): Promise<NativeHeliumConf
     environment: config.environment,
     wrapperSdkVersion: SDK_VERSION,
     delegateType: config.purchaseConfig?._delegateType,
-    consumableIds: config.consumableIds,
+    androidConsumableProductIds: config.androidConsumableProductIds,
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ const buildNativeConfig = async (config: HeliumConfig): Promise<NativeHeliumConf
     environment: config.environment,
     wrapperSdkVersion: SDK_VERSION,
     delegateType: config.purchaseConfig?._delegateType,
+    consumableIds: config.consumableIds,
   };
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a small, additive config plumbing change that only affects Android SDK initialization (plus an iOS warning log) with no auth/payment flow logic changes beyond passing IDs through.
> 
> **Overview**
> Adds a new `androidConsumableProductIds` option to the JS `HeliumConfig`/native config bridge and forwards it from `src/index.ts` into the native modules.
> 
> On Android, `HeliumPaywallSdkModule.initialize` now parses, trims, drops empty strings, and sets these IDs on `Helium.config.consumableIds`; on iOS the same config key is explicitly ignored with a console warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75887aca5ac81339e61107a65658d10d0895c58f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying consumable product IDs in the configuration for Android paywalls.

* **Documentation**
  * iOS now logs a runtime warning if Android-only consumable IDs are present, clarifying they will be ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->