### PR TITLE
Android update lightdark

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  implementation("com.tryhelium.paywall:core:4.2.0")
+  implementation("com.tryhelium.paywall:core:4.3.1")
   implementation("com.google.code.gson:gson:2.10.1")
   implementation("com.android.billingclient:billing:8.0.0")
   implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -23,6 +23,7 @@ import com.tryhelium.paywall.core.HeliumWrapperSdkConfig
 import com.tryhelium.paywall.core.PaywallPresentationConfig
 import com.tryhelium.paywall.delegate.HeliumPaywallDelegate
 import com.tryhelium.paywall.delegate.PlayStorePaywallDelegate
+import com.tryhelium.paywall.core.logger.HeliumLogLevel
 import com.tryhelium.paywall.core.logger.HeliumLogger
 import com.android.billingclient.api.ProductDetails
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -688,6 +689,7 @@ class DefaultPaywallDelegate(
  */
 class BridgingLogger : HeliumLogger {
   override val logTag: String = "Helium"
+  override var logLevel: HeliumLogLevel = HeliumLogLevel.ERROR
 
   // Also log to stdout so logcat still works
   private val stdoutLogger = HeliumLogger.Stdout

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -254,7 +254,7 @@ class HeliumPaywallSdkModule : Module() {
         val consumableIds = (config["androidConsumableProductIds"] as? List<*>)
           ?.mapNotNull { it as? String }
           ?.map { it.trim() }
-+         ?.filter { it.isNotEmpty() }
+          ?.filter { it.isNotEmpty() }
           ?.toSet()
         consumableIds?.let { Helium.config.consumableIds = it }
         customAPIEndpoint?.let { Helium.config.customApiEndpoint = it }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,10 +1,12 @@
 
 import {HeliumPaywallEvent, initialize, presentUpsell} from 'expo-helium';
-import { Button, SafeAreaView, ScrollView, Text, View } from 'react-native';
 import {useEffect} from "react";
+import { Button, SafeAreaView, ScrollView, Text, useColorScheme, View } from 'react-native';
 import {createCustomPurchaseConfig} from "expo-helium";
 
 export default function App() {
+  const isDark = useColorScheme() === 'dark';
+
   const asyncHeliumInit = async () => {
     await initialize({
       apiKey: 'api-key-here',
@@ -19,9 +21,9 @@ export default function App() {
   }, []);
 
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView style={styles.container}>
-        <Text style={styles.header}>Helium Example</Text>
+    <SafeAreaView style={[styles.container, { backgroundColor: isDark ? '#111' : '#eee' }]}>
+      <ScrollView style={[styles.container, { backgroundColor: isDark ? '#111' : '#eee' }]}>
+        <Text style={[styles.header, { color: isDark ? '#fff' : '#000' }]}>Helium Example</Text>
         <Group name="Paywall actions">
           <Button
             title="Show paywall!"
@@ -56,9 +58,10 @@ export default function App() {
 }
 
 function Group(props: { name: string; children: React.ReactNode }) {
+  const isDark = useColorScheme() === 'dark';
   return (
-    <View style={styles.group}>
-      <Text style={styles.groupHeader}>{props.name}</Text>
+    <View style={[styles.group, { backgroundColor: isDark ? '#222' : '#fff' }]}>
+      <Text style={[styles.groupHeader, { color: isDark ? '#fff' : '#000' }]}>{props.name}</Text>
       {props.children}
     </View>
   );

--- a/example/app.json
+++ b/example/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-helium",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Helium paywalls expo sdk",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
New android sdk update that fixes light/dark overrides and a couple other minor fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the underlying Android Helium core SDK, which can change paywall behavior and light/dark handling at runtime. Other changes are minor (logger default level and example app theming/version bumps).
> 
> **Overview**
> Updates the Android dependency `com.tryhelium.paywall:core` from `4.2.0` to `4.3.1` and adapts the Expo module to the new logger API by setting `BridgingLogger.logLevel` (defaulting to `ERROR`).
> 
> Also updates the example app to follow system light/dark mode (`userInterfaceStyle: automatic` and `useColorScheme()`-based styling), and bumps the package version to `3.3.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ffe1ff447f518efc775ed372e574d75241c097d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark mode UI is now supported with automatic color scheme detection that adapts to system preferences.
  * Added log level configuration for enhanced debugging capabilities.

* **Chores**
  * Updated the paywall SDK dependency to version 4.3.1.
  * Released version 3.3.5 with improvements and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->