### PR TITLE
Hel 4982 safer rc purchase

### DIFF
--- a/src/revenuecat/index.ts
+++ b/src/revenuecat/index.ts
@@ -1,1 +1,2 @@
-export { createRevenueCatPurchaseConfig } from "./revenuecat";
+export { createRevenueCatConfig } from "./revenuecat";
+export type { RevenueCatConfig } from "./revenuecat";

--- a/src/revenuecat/index.ts
+++ b/src/revenuecat/index.ts
@@ -1,2 +1,2 @@
-export { createRevenueCatConfig } from "./revenuecat";
+export { createRevenueCatPurchaseConfig } from "./revenuecat";
 export type { RevenueCatConfig } from "./revenuecat";

--- a/src/revenuecat/revenuecat.ts
+++ b/src/revenuecat/revenuecat.ts
@@ -75,11 +75,11 @@ export class RevenueCatHeliumHandler {
     try {
       rcProduct = await this.getProduct(productId);
     } catch {
-      return {status: 'failed', error: `[RC] Failed to retrieve product: ${productId}`};
+      return {status: 'failed', error: `[RevenueCat] Failed to retrieve product: ${productId}`};
     }
 
     if (!rcProduct) {
-      return {status: 'failed', error: `[RC] Product not found: ${productId}`};
+      return {status: 'failed', error: `[RevenueCat] iOS product not found: ${productId}`};
     }
 
     try {
@@ -137,11 +137,11 @@ export class RevenueCatHeliumHandler {
           rcProduct = products[0];
         }
       }
-      if (!rcProduct) {
-        return {status: 'failed', error: `[RC] Android product not found: ${productId}`};
-      }
     } catch {
-      return {status: 'failed', error: `[RC] Failed to retrieve Android product: ${productId}`};
+      return {status: 'failed', error: `[RevenueCat] Failed to retrieve Android product: ${productId}`};
+    }
+    if (!rcProduct) {
+      return {status: 'failed', error: `[RevenueCat] Android product not found: ${productId}`};
     }
 
     try {
@@ -224,8 +224,8 @@ export class RevenueCatHeliumHandler {
     const errorDesc = purchasesError?.message || 'purchase failed.';
     const underlying = purchasesError?.underlyingErrorMessage;
     const errorMsg = underlying
-      ? `[RC] ${errorDesc} code: ${purchasesError?.code} | ${underlying}`
-      : `[RC] ${errorDesc} code: ${purchasesError?.code}`;
+      ? `[RevenueCat] ${errorDesc} code: ${purchasesError?.code} | ${underlying}`
+      : `[RevenueCat] ${errorDesc} code: ${purchasesError?.code}`;
     return {status: 'failed', error: errorMsg};
   }
 

--- a/src/revenuecat/revenuecat.ts
+++ b/src/revenuecat/revenuecat.ts
@@ -9,13 +9,18 @@ import {Platform} from 'react-native';
 import {HeliumPaywallEvent, HeliumPurchaseConfig, HeliumPurchaseResult} from "../HeliumPaywallSdk.types";
 import {setRevenueCatAppUserId} from "../index";
 
-export function createRevenueCatPurchaseConfig(config?: {
+export interface RevenueCatConfig {
+  /** RevenueCat API key (cross-platform). Only needed if RevenueCat is not already configured externally (e.g. via Purchases.configure). */
   apiKey?: string;
+  /** iOS-specific RevenueCat API key. Takes precedence over `apiKey` on iOS. Only needed if RevenueCat is not already configured externally. */
   apiKeyIOS?: string;
+  /** Android-specific RevenueCat API key. Takes precedence over `apiKey` on Android. Only needed if RevenueCat is not already configured externally. */
   apiKeyAndroid?: string;
   /** Set to true to disable automatic RevenueCat entitlement syncing after Stripe purchases. */
   disableStripePurchaseSync?: boolean;
-}): HeliumPurchaseConfig {
+}
+
+export function createRevenueCatPurchaseConfig(config?: RevenueCatConfig): HeliumPurchaseConfig {
   const rcHandler = new RevenueCatHeliumHandler(config);
   return {
     makePurchaseIOS: rcHandler.makePurchaseIOS.bind(rcHandler),
@@ -30,7 +35,9 @@ export class RevenueCatHeliumHandler {
   private stripePurchaseSyncDisabled: boolean = false;
   private isSyncingStripePurchase: boolean = false;
 
-  constructor(config?: { apiKey?: string; apiKeyIOS?: string; apiKeyAndroid?: string; disableStripePurchaseSync?: boolean }) {
+  constructor(config?: RevenueCatConfig) {
+    this.stripePurchaseSyncDisabled = config?.disableStripePurchaseSync ?? false;
+
     // Determine which API key to use based on platform
     let effectiveApiKey: string | undefined;
     if (Platform.OS === 'ios' && config?.apiKeyIOS) {
@@ -41,12 +48,19 @@ export class RevenueCatHeliumHandler {
       effectiveApiKey = config?.apiKey;
     }
 
-    if (effectiveApiKey) {
-      Purchases.configure({apiKey: effectiveApiKey});
+    void this.setUp(effectiveApiKey);
+  }
+
+  private async setUp(apiKey?: string): Promise<void> {
+    if (apiKey) {
+      if (await Purchases.isConfigured()) {
+        console.log('[Helium] RevenueCat is already configured, ignoring provided RevenueCat api key.');
+      } else {
+        Purchases.configure({apiKey: apiKey});
+      }
     }
-    this.stripePurchaseSyncDisabled = config?.disableStripePurchaseSync ?? false;
     // Keep this value as up-to-date as possible
-    void this.syncRevenueCatAppUserId();
+    await this.syncRevenueCatAppUserId();
   }
 
   private async syncRevenueCatAppUserId(): Promise<void> {

--- a/src/revenuecat/revenuecat.ts
+++ b/src/revenuecat/revenuecat.ts
@@ -257,6 +257,10 @@ export class RevenueCatHeliumHandler {
     return products.length > 0 ? products[0] : undefined;
   }
 
+  // Intentionally broad: retry ALL failures, not just known-transient ones.
+  // Most store errors (code 2, 10) are transient. The cost of one extra attempt
+  // (~1s delay) is low; the cost of not retrying a recoverable failure is a lost purchase.
+  // Restricting to specific RC error codes can miss new transient types.
   private isRetryableResult(result: HeliumPurchaseResult): boolean {
     return result.status === 'failed';
   }

--- a/src/revenuecat/revenuecat.ts
+++ b/src/revenuecat/revenuecat.ts
@@ -2,7 +2,6 @@ import type {
   CustomerInfo,
   PurchasesEntitlementInfo,
   PurchasesError,
-  PurchasesPackage,
   SubscriptionOption
 } from 'react-native-purchases';
 import Purchases, {PRODUCT_CATEGORY, PURCHASES_ERROR_CODE, PurchasesStoreProduct} from 'react-native-purchases';
@@ -10,7 +9,6 @@ import {Platform} from 'react-native';
 import {HeliumPaywallEvent, HeliumPurchaseConfig, HeliumPurchaseResult} from "../HeliumPaywallSdk.types";
 import {setRevenueCatAppUserId} from "../index";
 
-// Rename the factory function
 export function createRevenueCatPurchaseConfig(config?: {
   apiKey?: string;
   apiKeyIOS?: string;
@@ -29,13 +27,8 @@ export function createRevenueCatPurchaseConfig(config?: {
 }
 
 export class RevenueCatHeliumHandler {
-  private productIdToPackageMapping: Record<string, PurchasesPackage> = {};
-  private isMappingInitialized: boolean = false;
-  private initializationPromise: Promise<void> | null = null;
   private stripePurchaseSyncDisabled: boolean = false;
   private isSyncingStripePurchase: boolean = false;
-
-  private rcProductToPackageMapping: Record<string, PurchasesStoreProduct> = {};
 
   constructor(config?: { apiKey?: string; apiKeyIOS?: string; apiKeyAndroid?: string; disableStripePurchaseSync?: boolean }) {
     // Determine which API key to use based on platform
@@ -52,79 +45,45 @@ export class RevenueCatHeliumHandler {
       Purchases.configure({apiKey: effectiveApiKey});
     }
     this.stripePurchaseSyncDisabled = config?.disableStripePurchaseSync ?? false;
-    void this.initializePackageMapping();
+    // Keep this value as up-to-date as possible
+    void this.syncRevenueCatAppUserId();
   }
 
-  private async initializePackageMapping(): Promise<void> {
-    if (this.initializationPromise) {
-      return this.initializationPromise;
-    }
-    this.initializationPromise = (async () => {
-      try {
-        // Keep this value as up-to-date as possible
-        setRevenueCatAppUserId(await Purchases.getAppUserID());
-
-        const offerings = await Purchases.getOfferings();
-        const allOfferings = offerings.all;
-        for (const offering of Object.values(allOfferings)) {
-          offering.availablePackages.forEach((pkg: PurchasesPackage) => {
-            if (pkg.product?.identifier) {
-              this.productIdToPackageMapping[pkg.product.identifier] = pkg;
-            }
-          });
-        }
-        this.isMappingInitialized = true;
-      } catch (error) {
-        this.isMappingInitialized = false;
-      } finally {
-        this.initializationPromise = null;
-      }
-    })();
-    return this.initializationPromise;
-  }
-
-  private async ensureMappingInitialized(): Promise<void> {
-    if (!this.isMappingInitialized && !this.initializationPromise) {
-      await this.initializePackageMapping();
-    } else if (this.initializationPromise) {
-      await this.initializationPromise;
+  private async syncRevenueCatAppUserId(): Promise<void> {
+    try {
+      const id = await Purchases.getAppUserID();
+      setRevenueCatAppUserId(id);
+    } catch {
+      console.log('[Helium] Could not sync RevenueCat app user ID.');
     }
   }
 
   async makePurchaseIOS(productId: string): Promise<HeliumPurchaseResult> {
     // Keep this value as up-to-date as possible
-    setRevenueCatAppUserId(await Purchases.getAppUserID());
+    await this.syncRevenueCatAppUserId();
+    const result = await this.attemptPurchaseIOS(productId);
 
-    await this.ensureMappingInitialized();
-    const pkg: PurchasesPackage | undefined = this.productIdToPackageMapping[productId];
+    if (this.isRetryableResult(result)) {
+      await this.delay(1000);
+      return this.attemptPurchaseIOS(productId);
+    }
+    return result;
+  }
+
+  private async attemptPurchaseIOS(productId: string): Promise<HeliumPurchaseResult> {
     let rcProduct: PurchasesStoreProduct | undefined;
-    if (!pkg) {
-      // Use cached if available
-      rcProduct = this.rcProductToPackageMapping[productId];
-      if (!rcProduct) {
-        // Try to retrieve now
-        try {
-          const rcProducts = await Purchases.getProducts([productId]);
-          rcProduct = rcProducts.length > 0 ? rcProducts[0] : undefined;
-        } catch {
-          // 'failed' status will be returned
-        }
-        if (rcProduct) {
-          this.rcProductToPackageMapping[productId] = rcProduct;
-        }
-      }
+    try {
+      rcProduct = await this.getProduct(productId);
+    } catch {
+      return {status: 'failed', error: `[RC] Failed to retrieve product: ${productId}`};
+    }
+
+    if (!rcProduct) {
+      return {status: 'failed', error: `[RC] Product not found: ${productId}`};
     }
 
     try {
-      let purchaseResult;
-      if (pkg) {
-        purchaseResult = await Purchases.purchasePackage(pkg);
-      } else if (rcProduct) {
-        purchaseResult = await Purchases.purchaseStoreProduct(rcProduct);
-      } else {
-        return {status: 'failed', error: `RevenueCat Product/Package not found for ID: ${productId}`};
-      }
-
+      const purchaseResult = await Purchases.purchaseStoreProduct(rcProduct);
       const transactionId = purchaseResult.transaction?.transactionIdentifier;
       return this.evaluatePurchaseResult(purchaseResult.customerInfo, productId, transactionId);
     } catch (error) {
@@ -132,11 +91,19 @@ export class RevenueCatHeliumHandler {
     }
   }
 
-  // Android-specific purchase logic (completely separated from iOS)
   async makePurchaseAndroid(productId: string, basePlanId?: string, offerId?: string): Promise<HeliumPurchaseResult> {
     // Keep this value as up-to-date as possible
-    setRevenueCatAppUserId(await Purchases.getAppUserID());
+    await this.syncRevenueCatAppUserId();
+    const result = await this.attemptPurchaseAndroid(productId, basePlanId, offerId);
 
+    if (this.isRetryableResult(result)) {
+      await this.delay(1000);
+      return this.attemptPurchaseAndroid(productId, basePlanId, offerId);
+    }
+    return result;
+  }
+
+  private async attemptPurchaseAndroid(productId: string, basePlanId?: string, offerId?: string): Promise<HeliumPurchaseResult> {
     // Handle subscription with base plan or offer
     if (basePlanId || offerId) {
       const subscriptionOption = await this.findAndroidSubscriptionOption(
@@ -255,7 +222,11 @@ export class RevenueCatHeliumHandler {
     }
 
     const errorDesc = purchasesError?.message || 'purchase failed.';
-    return {status: 'failed', error: `[RC] ${errorDesc} code: ${purchasesError?.code}`};
+    const underlying = purchasesError?.underlyingErrorMessage;
+    const errorMsg = underlying
+      ? `[RC] ${errorDesc} code: ${purchasesError?.code} | ${underlying}`
+      : `[RC] ${errorDesc} code: ${purchasesError?.code}`;
+    return {status: 'failed', error: errorMsg};
   }
 
   async restorePurchases(): Promise<boolean> {
@@ -265,6 +236,15 @@ export class RevenueCatHeliumHandler {
     } catch (error) {
       return false;
     }
+  }
+
+  private async getProduct(productId: string): Promise<PurchasesStoreProduct | undefined> {
+    const products = await Purchases.getProducts([productId]);
+    return products.length > 0 ? products[0] : undefined;
+  }
+
+  private isRetryableResult(result: HeliumPurchaseResult): boolean {
+    return result.status === 'failed';
   }
 
   onHeliumEvent(event: HeliumPaywallEvent): void {

--- a/src/revenuecat/revenuecat.ts
+++ b/src/revenuecat/revenuecat.ts
@@ -34,6 +34,7 @@ export function createRevenueCatPurchaseConfig(config?: RevenueCatConfig): Heliu
 export class RevenueCatHeliumHandler {
   private stripePurchaseSyncDisabled: boolean = false;
   private isSyncingStripePurchase: boolean = false;
+  private setUpPromise: Promise<void>;
 
   constructor(config?: RevenueCatConfig) {
     this.stripePurchaseSyncDisabled = config?.disableStripePurchaseSync ?? false;
@@ -48,15 +49,19 @@ export class RevenueCatHeliumHandler {
       effectiveApiKey = config?.apiKey;
     }
 
-    void this.setUp(effectiveApiKey);
+    this.setUpPromise = this.setUp(effectiveApiKey);
   }
 
   private async setUp(apiKey?: string): Promise<void> {
     if (apiKey) {
-      if (await Purchases.isConfigured()) {
-        console.log('[Helium] RevenueCat is already configured, ignoring provided RevenueCat api key.');
-      } else {
-        Purchases.configure({apiKey: apiKey});
+      try {
+        if (await Purchases.isConfigured()) {
+          console.log('[Helium] RevenueCat is already configured, ignoring provided RevenueCat api key.');
+        } else {
+          Purchases.configure({apiKey: apiKey});
+        }
+      } catch {
+        console.log('[Helium] Failed to configure RevenueCat.');
       }
     }
     // Keep this value as up-to-date as possible
@@ -73,6 +78,7 @@ export class RevenueCatHeliumHandler {
   }
 
   async makePurchaseIOS(productId: string): Promise<HeliumPurchaseResult> {
+    await this.setUpPromise;
     // Keep this value as up-to-date as possible
     await this.syncRevenueCatAppUserId();
     const result = await this.attemptPurchaseIOS(productId);
@@ -106,6 +112,7 @@ export class RevenueCatHeliumHandler {
   }
 
   async makePurchaseAndroid(productId: string, basePlanId?: string, offerId?: string): Promise<HeliumPurchaseResult> {
+    await this.setUpPromise;
     // Keep this value as up-to-date as possible
     await this.syncRevenueCatAppUserId();
     const result = await this.attemptPurchaseAndroid(productId, basePlanId, offerId);


### PR DESCRIPTION
* Remove offering checks and package map, just retrieve product fresh every purchase attempt
* Add a retry if unexpected purchase failure occurs
* RC -> RevenueCat for clearer error trail in error messages
* Some refactoring, improved docstrings, and ignore api key if already configured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core in-app purchase flow by removing offering/package mapping and adding automatic retries, which could affect purchase reliability and error handling behavior across iOS/Android.
> 
> **Overview**
> Improves the RevenueCat purchase integration by introducing an exported `RevenueCatConfig` type and a guarded setup step that *only configures RevenueCat if it isn’t already configured*.
> 
> Refactors purchases to fetch products on-demand (removing offering/package mapping) and adds a 1s retry on any failed purchase attempt for both iOS and Android. Error messages are standardized from `[RC]` to `[RevenueCat]` and now include underlying RevenueCat error details when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4224d7884b0fee18bf704f42e17e81eb8248156b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a new public RevenueCat configuration type for clearer cross-platform setup.

* **Refactor**
  * Improved RevenueCat integration with guarded setup, synchronized app-user handling, and clearer error messages.
  * Enhanced Android subscription handling with fallback paths for missing options.
  * Added automatic retry for transient purchase failures to increase success rates and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->