### PR TITLE
Hel 5036 3rdpartyid

### DIFF
--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -420,6 +420,10 @@ class HeliumPaywallSdkModule : Module() {
       Helium.identity.userId = newUserId
     }
 
+    Function("setThirdPartyAnalyticsAnonymousId") { anonymousId: String? ->
+      Helium.identity.thirdPartyAnalyticsAnonymousId = anonymousId
+    }
+
     // Check if user has entitlement for a specific paywall
     AsyncFunction("hasEntitlementForPaywall") Coroutine { trigger: String ->
       val result = Helium.entitlements.hasEntitlementForPaywall(trigger)

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -296,6 +296,10 @@ public class HeliumPaywallSdkModule: Module {
         Helium.identify.userId = newUserId
     }
 
+    Function("setThirdPartyAnalyticsAnonymousId") { (anonymousId: String?) in
+        Helium.identify.thirdPartyAnalyticsAnonymousId = anonymousId
+    }
+
     AsyncFunction("hasEntitlementForPaywall") { (trigger: String) in
       let hasEntitlement = await Helium.entitlements.hasEntitlementForPaywall(trigger: trigger)
       return HasEntitlementResult(hasEntitlement: hasEntitlement)

--- a/src/HeliumPaywallSdkModule.ts
+++ b/src/HeliumPaywallSdkModule.ts
@@ -65,6 +65,8 @@ declare class HeliumPaywallSdkModule extends NativeModule<HeliumPaywallSdkModule
 
   setCustomUserId(newUserId: string): void;
 
+  setThirdPartyAnalyticsAnonymousId(anonymousId: string | null): void;
+
   hasEntitlementForPaywall(trigger: string): Promise<HasEntitlementResult>;
 
   hasAnyActiveSubscription(): Promise<boolean>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,7 +383,15 @@ export const setRevenueCatAppUserId = HeliumPaywallSdkModule.setRevenueCatAppUse
 export const setCustomUserId = HeliumPaywallSdkModule.setCustomUserId;
 
 /**
- * Set or clear a third-party analytics anonymous ID for the current user. Pass null to clear.
+ * An optional anonymous ID from your third-party analytics provider, sent alongside
+ * every Helium analytics event so you can correlate Helium data with your own analytics
+ * before you have set a custom user ID. Pass `null` to clear.
+ *
+ * - Amplitude: pass device ID
+ * - Mixpanel: pass anonymous ID
+ * - PostHog: pass anonymous ID
+ *
+ * Set this before calling `initialize()` for best results. Can also be updated after initialization.
  */
 export const setThirdPartyAnalyticsAnonymousId =
   HeliumPaywallSdkModule.setThirdPartyAnalyticsAnonymousId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,12 @@ export const setRevenueCatAppUserId = HeliumPaywallSdkModule.setRevenueCatAppUse
 export const setCustomUserId = HeliumPaywallSdkModule.setCustomUserId;
 
 /**
+ * Set or clear a third-party analytics anonymous ID for the current user. Pass null to clear.
+ */
+export const setThirdPartyAnalyticsAnonymousId =
+  HeliumPaywallSdkModule.setThirdPartyAnalyticsAnonymousId;
+
+/**
  * Checks if the user has an active entitlement for any product attached to the paywall that will show for provided trigger.
  * @param trigger The trigger name to check entitlement for
  * @returns Promise resolving to true if entitled, false if not, or undefined if not known (i.e. the paywall is not downloaded yet)

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,8 +393,13 @@ export const setCustomUserId = HeliumPaywallSdkModule.setCustomUserId;
  *
  * Set this before calling `initialize()` for best results. Can also be updated after initialization.
  */
-export const setThirdPartyAnalyticsAnonymousId =
-  HeliumPaywallSdkModule.setThirdPartyAnalyticsAnonymousId;
+export const setThirdPartyAnalyticsAnonymousId = (anonymousId: string | null): void => {
+  try {
+    HeliumPaywallSdkModule.setThirdPartyAnalyticsAnonymousId(anonymousId);
+  } catch (e) {
+    console.error('[Helium] Failed to set third-party analytics anonymous ID', e);
+  }
+};
 
 /**
  * Checks if the user has an active entitlement for any product attached to the paywall that will show for provided trigger.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk additive API change that only sets an optional identity field on native SDKs and adds a JS wrapper; no behavioral changes unless the new method is called.
> 
> **Overview**
> Adds a new cross-platform API, `setThirdPartyAnalyticsAnonymousId`, to pass an optional third-party analytics anonymous identifier through to the native Helium identity layer (Android `Helium.identity` / iOS `Helium.identify`).
> 
> Updates the TypeScript native module typing and exports a documented JS helper that forwards the value (or `null` to clear) and logs an error if the native call fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a613b23c1ae63420dcfdebdae58b5fc56b8388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API to set a third-party analytics anonymous ID (accepts a string or null to clear).
  * Can be called before or after SDK initialization.
  * Available on both Android and iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->