### PR TITLE
empty api key safety; refactoring and more queue cleanup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,4 @@ dependencies {
   implementation("com.tryhelium.paywall:core:4.4.0")
   implementation("com.google.code.gson:gson:2.10.1")
   implementation("com.android.billingclient:billing:8.0.0")
-  implementation("org.jetbrains.kotlin:kotlin-reflect")
 }

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -30,8 +30,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import java.lang.ref.WeakReference
 import java.net.URL
 import kotlin.coroutines.resume
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.isAccessible
 
 // Record data classes for type-safe return values
 class PaywallInfoResult : Record {
@@ -76,6 +74,12 @@ private object NativeModuleManager {
 
   fun clearRestore() {
     restoreContinuation = null
+  }
+
+  fun clearPendingEvents() {
+    synchronized(pendingEvents) {
+      pendingEvents.clear()
+    }
   }
 
   // Queue an event for later delivery when module becomes available
@@ -175,10 +179,15 @@ class HeliumPaywallSdkModule : Module() {
 
     // Initialize the Helium SDK with configuration
     Function("initialize") { config: Map<String, Any?> ->
+      val apiKey = config["apiKey"] as? String
+      if (apiKey.isNullOrEmpty()) {
+        android.util.Log.e("HeliumPaywallSdk", "initialize called with missing/empty apiKey; aborting.")
+        return@Function
+      }
+
       NativeModuleManager.currentModule = this@HeliumPaywallSdkModule // extra redundancy to update to latest live module
       NativeModuleManager.flushEvents(this@HeliumPaywallSdkModule)
 
-      val apiKey = config["apiKey"] as? String ?: ""
       val customUserId = config["customUserId"] as? String
       val customAPIEndpoint = config["customAPIEndpoint"] as? String
       val revenueCatAppUserId = config["revenueCatAppUserId"] as? String
@@ -201,7 +210,7 @@ class HeliumPaywallSdkModule : Module() {
         // Setting <= 0 will disable loading state
         Helium.config.defaultLoadingBudgetInMs = -1
       } else {
-        Helium.config.defaultLoadingBudgetInMs = loadingBudgetMs ?: DEFAULT_LOADING_BUDGET_MS
+        Helium.config.defaultLoadingBudgetInMs = loadingBudgetMs
       }
 
       // Parse environment parameter, defaulting to PRODUCTION
@@ -324,6 +333,7 @@ class HeliumPaywallSdkModule : Module() {
     // Present a paywall with the given trigger
     Function("presentUpsell") { trigger: String, customPaywallTraits: Map<String, Any>?, dontShowIfAlreadyEntitled: Boolean?, disableSystemBackNavigation: Boolean? ->
       NativeModuleManager.currentModule = this@HeliumPaywallSdkModule // extra redundancy to update to latest live module
+      NativeModuleManager.flushEvents(this@HeliumPaywallSdkModule)
 
       // Convert custom paywall traits
       val convertedTraits = convertToHeliumUserTraits(customPaywallTraits)
@@ -488,6 +498,7 @@ class HeliumPaywallSdkModule : Module() {
     AsyncFunction("resetHelium") Coroutine { clearUserTraits: Boolean, clearHeliumEventListeners: Boolean, clearExperimentAllocations: Boolean ->
       // Reset logger so initialize() can set up a fresh BridgingLogger
       Helium.config.logger = HeliumLogger.Stdout
+      NativeModuleManager.clearPendingEvents()
       try {
         suspendCancellableCoroutine<Unit> { continuation ->
           Helium.resetHelium(

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -10,7 +10,7 @@ enum PurchaseError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case let .unknownStatus(status):
-            return "Purchased not successful due to unknown status - \(status)."
+            return "Purchase not successful due to unknown status - \(status)."
         case let .purchaseFailed(errorMsg):
             return errorMsg
         }
@@ -83,6 +83,12 @@ private class NativeModuleManager {
 
     func clearRestore() {
         activeRestoreContinuation = nil
+    }
+
+    func clearPendingEvents() {
+        eventLock.lock()
+        pendingEvents.removeAll()
+        eventLock.unlock()
     }
 
     // Queue an event for later delivery when module becomes available
@@ -170,8 +176,12 @@ public class HeliumPaywallSdkModule: Module {
 
     // todo use Record here? https://docs.expo.dev/modules/module-api/#records
     Function("initialize") { (config: [String : Any]) in
+      guard let apiKey = config["apiKey"] as? String, !apiKey.isEmpty else {
+        print("[Helium] initialize called with missing/empty apiKey; aborting.")
+        return
+      }
       performCoreSetup(config)
-      Helium.shared.initialize(apiKey: config["apiKey"] as? String ?? "")
+      Helium.shared.initialize(apiKey: apiKey)
     }
 
     Function("setupCore") { (config: [String : Any]) in
@@ -229,6 +239,7 @@ public class HeliumPaywallSdkModule: Module {
 
     Function("presentUpsell") { (trigger: String, customPaywallTraits: [String: Any]?, dontShowIfAlreadyEntitled: Bool?, _disableSystemBackNavigation: Bool?) in
         NativeModuleManager.shared.currentModule = self // extra redundancy to update to latest live module
+        NativeModuleManager.shared.flushEvents(module: self)
         var paywallTraits: HeliumUserTraits? = nil
         if let paywallTraitsMap = convertMarkersToBooleans(customPaywallTraits) {
             paywallTraits = HeliumUserTraits(paywallTraitsMap)
@@ -353,6 +364,7 @@ public class HeliumPaywallSdkModule: Module {
       // Clean up log listener so performCoreSetup can re-register on next initialize()
       NativeModuleManager.shared.logListenerToken?.remove()
       NativeModuleManager.shared.logListenerToken = nil
+      NativeModuleManager.shared.clearPendingEvents()
       await withUnsafeContinuation { (continuation: UnsafeContinuation<Void, Never>) in
         Helium.resetHelium(
           clearUserTraits: clearUserTraits,

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -301,4 +301,4 @@ export interface ResetHeliumOptions {
 export const HELIUM_CTA_NAMES = {
   SCHEDULE_CALL: 'schedule_call',
   SUBSCRIBE_BUTTON: 'subscribe_button',
-}
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,11 @@ const HELIUM_EVENT_NAMES = [
 
 const removeAllHeliumListeners = () => {
   for (const name of HELIUM_EVENT_NAMES) {
-    HeliumPaywallSdkModule.removeAllListeners(name);
+    try {
+      HeliumPaywallSdkModule.removeAllListeners(name);
+    } catch (e) {
+      console.warn(`[Helium] Failed to remove listeners for ${name}:`, e);
+    }
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,22 @@ function addEntitledEventListener(listener: () => void): EventSubscription {
 
 let isInitialized = false;
 
+const HELIUM_EVENT_NAMES = [
+  'onHeliumPaywallEvent',
+  'onDelegateActionEvent',
+  'paywallEventHandlers',
+  'onHeliumLogEvent',
+  'onEntitledEvent',
+] as const;
+
+const removeAllHeliumListeners = () => {
+  for (const name of HELIUM_EVENT_NAMES) {
+    HeliumPaywallSdkModule.removeAllListeners(name);
+  }
+};
+
 function setupEventListeners(config: HeliumConfig) {
-  HeliumPaywallSdkModule.removeAllListeners('onHeliumPaywallEvent');
-  HeliumPaywallSdkModule.removeAllListeners('onDelegateActionEvent');
-  HeliumPaywallSdkModule.removeAllListeners('paywallEventHandlers');
-  HeliumPaywallSdkModule.removeAllListeners('onHeliumLogEvent');
-  HeliumPaywallSdkModule.removeAllListeners('onEntitledEvent');
+  removeAllHeliumListeners();
 
   // Set up listener for paywall events
   addHeliumPaywallEventListener((event) => {
@@ -116,9 +126,10 @@ function setupEventListeners(config: HeliumConfig) {
         }
       } catch (error) {
         // Send failure result based on action type
+        const errorMsg = error instanceof Error ? error.message : String(error);
         if (event.type === 'purchase') {
           console.log('[Helium] Unexpected error: ', error);
-          HeliumPaywallSdkModule.handlePurchaseResult('failed');
+          HeliumPaywallSdkModule.handlePurchaseResult('failed', errorMsg);
         } else if (event.type === 'restore') {
           HeliumPaywallSdkModule.handleRestoreResult(false);
         }
@@ -207,25 +218,33 @@ export const _setupCore = async (config: HeliumConfig) => {
     return;
   }
   isInitialized = true;
-  setupEventListeners(config);
   try {
+    setupEventListeners(config);
     const nativeConfig = await buildNativeConfig(config);
     HeliumPaywallSdkModule.setupCore(nativeConfig);
   } catch (error) {
+    isInitialized = false;
+    removeAllHeliumListeners();
     console.error('[Helium] Setup failed:', error);
   }
 };
 
 export const initialize = async (config: HeliumConfig) => {
+  if (!config.apiKey) {
+    console.error('[Helium] initialize called without an apiKey; aborting.');
+    return;
+  }
   if (isInitialized) {
     return;
   }
   isInitialized = true;
-  setupEventListeners(config);
   try {
+    setupEventListeners(config);
     const nativeConfig = await buildNativeConfig(config);
     HeliumPaywallSdkModule.initialize(nativeConfig);
   } catch (error) {
+    isInitialized = false;
+    removeAllHeliumListeners();
     console.error('[Helium] Initialization failed:', error);
   }
 };
@@ -428,11 +447,7 @@ export const resetHelium = async (options?: ResetHeliumOptions): Promise<void> =
   paywallEventHandlers = undefined;
   presentOnPaywallUnavailable = undefined;
   presentOnEntitled = undefined;
-  HeliumPaywallSdkModule.removeAllListeners('onHeliumPaywallEvent');
-  HeliumPaywallSdkModule.removeAllListeners('onDelegateActionEvent');
-  HeliumPaywallSdkModule.removeAllListeners('paywallEventHandlers');
-  HeliumPaywallSdkModule.removeAllListeners('onHeliumLogEvent');
-  HeliumPaywallSdkModule.removeAllListeners('onEntitledEvent');
+  removeAllHeliumListeners();
 
   try {
     await HeliumPaywallSdkModule.resetHelium(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SDK initialization, event delivery, and purchase error propagation across JS/native bridges; behavior changes could affect paywall presentation or listener wiring if integrations relied on previous lenient defaults.
> 
> **Overview**
> Adds **explicit `apiKey` validation** on JS, Android, and iOS `initialize`, aborting early (and cleaning up JS state/listeners on failure) instead of silently initializing with an empty key.
> 
> Improves reliability around event delivery and teardown: queued native events are flushed when calling `presentUpsell`, pending event queues are cleared on `resetHelium`, and JS listener cleanup is refactored into a shared `removeAllHeliumListeners` helper.
> 
> Also removes unused Android `kotlin-reflect` usage/dependency, fixes an iOS purchase error string typo, propagates unexpected JS purchase errors back to native via `handlePurchaseResult('failed', errorMsg)`, and tightens TS constants typing with `as const`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e158f8583bb088e0ec69471614da70de5b2cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error message text in purchase failure notifications
  * Added validation for required API key during initialization to prevent silent startup failures
  * Improved error messaging in purchase operations with detailed error context

* **Improvements**
  * Enhanced event queue management for greater reliability
  * Strengthened TypeScript type definitions for better type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->