### PR TITLE
SDK-21 use locks for safer thread safety with purchase/restore continuations

### DIFF
--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -53,12 +53,17 @@ private object NativeModuleManager {
   private const val MAX_QUEUED_EVENTS = 30
   private const val EVENT_EXPIRATION_MS = 30_000L
 
-  // Always keep reference to the current module
+  // Written on the RN module thread; read from background threads (Helium log listener,
+  // SDK coroutine dispatcher). @Volatile ensures cross-thread visibility of the reference.
+  @Volatile
   var currentModule: HeliumPaywallSdkModule? = null
 
-  // Store active operations
-  var purchaseContinuation: ((HeliumPaywallTransactionStatus) -> Unit)? = null
-  var restoreContinuation: ((Boolean) -> Unit)? = null
+  // Guards the active purchase/restore continuations against cross-thread races between
+  // the Expo module thread (handlePurchaseResult) and the Helium SDK coroutine dispatcher
+  // (makePurchase).
+  private val continuationLock = Any()
+  private var _purchaseContinuation: ((HeliumPaywallTransactionStatus) -> Unit)? = null
+  private var _restoreContinuation: ((Boolean) -> Unit)? = null
 
   // Event queue for when no module is available in the registry
   private data class PendingEvent(
@@ -68,12 +73,52 @@ private object NativeModuleManager {
   )
   private val pendingEvents = mutableListOf<PendingEvent>()
 
-  fun clearPurchase() {
-    purchaseContinuation = null
+  fun setPurchaseContinuation(continuation: (HeliumPaywallTransactionStatus) -> Unit) {
+    val orphan = synchronized(continuationLock) {
+      val existing = _purchaseContinuation
+      _purchaseContinuation = continuation
+      existing
+    }
+    orphan?.invoke(HeliumPaywallTransactionStatus.Cancelled)
   }
 
-  fun clearRestore() {
-    restoreContinuation = null
+  fun takePurchaseContinuation(): ((HeliumPaywallTransactionStatus) -> Unit)? = synchronized(continuationLock) {
+    val c = _purchaseContinuation
+    _purchaseContinuation = null
+    c
+  }
+
+  // Cancellation handler clears only its own continuation — a later setPurchaseContinuation
+  // could already have replaced the stored value, and we must not wipe that newer one.
+  fun clearPurchaseContinuationIf(expected: (HeliumPaywallTransactionStatus) -> Unit) {
+    synchronized(continuationLock) {
+      if (_purchaseContinuation === expected) {
+        _purchaseContinuation = null
+      }
+    }
+  }
+
+  fun setRestoreContinuation(continuation: (Boolean) -> Unit) {
+    val orphan = synchronized(continuationLock) {
+      val existing = _restoreContinuation
+      _restoreContinuation = continuation
+      existing
+    }
+    orphan?.invoke(false)
+  }
+
+  fun takeRestoreContinuation(): ((Boolean) -> Unit)? = synchronized(continuationLock) {
+    val c = _restoreContinuation
+    _restoreContinuation = null
+    c
+  }
+
+  fun clearRestoreContinuationIf(expected: (Boolean) -> Unit) {
+    synchronized(continuationLock) {
+      if (_restoreContinuation === expected) {
+        _restoreContinuation = null
+      }
+    }
   }
 
   fun clearPendingEvents() {
@@ -297,7 +342,11 @@ class HeliumPaywallSdkModule : Module() {
 
     // Function for JavaScript to provide purchase result
     Function("handlePurchaseResult") { statusString: String, errorMsg: String?, transactionId: String?, originalTransactionId: String?, productId: String? ->
-      val continuation = NativeModuleManager.purchaseContinuation ?: return@Function
+      val continuation = NativeModuleManager.takePurchaseContinuation()
+      if (continuation == null) {
+        android.util.Log.w("HeliumPaywallSdk", "handlePurchaseResult called with no active continuation")
+        return@Function
+      }
 
       // Parse status string
       val lowercasedStatus = statusString.lowercase()
@@ -314,19 +363,17 @@ class HeliumPaywallSdkModule : Module() {
         )
       }
 
-      // Clear the singleton state
-      NativeModuleManager.clearPurchase()
-
       // Resume the continuation with the status
       continuation(status)
     }
 
     // Function for JavaScript to provide restore result
     Function("handleRestoreResult") { success: Boolean ->
-      val continuation = NativeModuleManager.restoreContinuation ?: return@Function
-
-      // Clear the singleton state
-      NativeModuleManager.clearRestore()
+      val continuation = NativeModuleManager.takeRestoreContinuation()
+      if (continuation == null) {
+        android.util.Log.w("HeliumPaywallSdk", "handleRestoreResult called with no active continuation")
+        return@Function
+      }
       continuation(success)
     }
 
@@ -604,19 +651,13 @@ class CustomPaywallDelegate(
     offerId: String?
   ): HeliumPaywallTransactionStatus {
     return suspendCancellableCoroutine { continuation ->
-      // First check singleton for orphaned continuation and clean it up
-      NativeModuleManager.purchaseContinuation?.let { existingContinuation ->
-        existingContinuation(HeliumPaywallTransactionStatus.Cancelled)
-        NativeModuleManager.clearPurchase()
-      }
-
-      NativeModuleManager.purchaseContinuation = { status ->
+      val resumeCallback: (HeliumPaywallTransactionStatus) -> Unit = { status ->
         continuation.resume(status)
       }
+      NativeModuleManager.setPurchaseContinuation(resumeCallback)
 
-      // Clean up on cancellation to prevent memory leaks and crashes
       continuation.invokeOnCancellation {
-        NativeModuleManager.clearPurchase()
+        NativeModuleManager.clearPurchaseContinuationIf(resumeCallback)
       }
 
       // Send event to JavaScript with separate parameters
@@ -637,19 +678,13 @@ class CustomPaywallDelegate(
 
   override suspend fun restorePurchases(): Boolean {
     return suspendCancellableCoroutine { continuation ->
-      // Check singleton for orphaned continuation and clean it up
-      NativeModuleManager.restoreContinuation?.let { existingContinuation ->
-        existingContinuation(false)
-        NativeModuleManager.clearRestore()
-      }
-
-      NativeModuleManager.restoreContinuation = { success ->
+      val resumeCallback: (Boolean) -> Unit = { success ->
         continuation.resume(success)
       }
+      NativeModuleManager.setRestoreContinuation(resumeCallback)
 
-      // Clean up on cancellation to prevent memory leaks and crashes
       continuation.invokeOnCancellation {
-        NativeModuleManager.clearRestore()
+        NativeModuleManager.clearRestoreContinuationIf(resumeCallback)
       }
 
       // Send event to JavaScript

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -43,9 +43,12 @@ private class NativeModuleManager {
     // Always keep reference to the current module
     var currentModule: HeliumPaywallSdkModule?
 
-    // Store active operations
-    var activePurchaseContinuation: CheckedContinuation<HeliumPaywallTransactionStatus, Never>?
-    var activeRestoreContinuation: CheckedContinuation<Bool, Never>?
+    // Guards the active purchase/restore continuations against cross-thread races between
+    // the Expo module thread (handlePurchaseResult) and the Swift-concurrency executor
+    // (makePurchase). Without it, both sides can double-resume and CheckedContinuation traps.
+    private let continuationLock = NSLock()
+    private var _activePurchaseContinuation: CheckedContinuation<HeliumPaywallTransactionStatus, Never>?
+    private var _activeRestoreContinuation: CheckedContinuation<Bool, Never>?
 
     // Transaction result tracking for HeliumDelegateReturnsTransaction
     private var _latestTransactionResult: HeliumTransactionIdResult?
@@ -77,12 +80,36 @@ private class NativeModuleManager {
 
     private init() {}
 
-    func clearPurchase() {
-        activePurchaseContinuation = nil
+    func setPurchaseContinuation(_ continuation: CheckedContinuation<HeliumPaywallTransactionStatus, Never>) {
+        continuationLock.lock()
+        let orphan = _activePurchaseContinuation
+        _activePurchaseContinuation = continuation
+        continuationLock.unlock()
+        orphan?.resume(returning: .cancelled)
     }
 
-    func clearRestore() {
-        activeRestoreContinuation = nil
+    func takePurchaseContinuation() -> CheckedContinuation<HeliumPaywallTransactionStatus, Never>? {
+        continuationLock.lock()
+        defer { continuationLock.unlock() }
+        let continuation = _activePurchaseContinuation
+        _activePurchaseContinuation = nil
+        return continuation
+    }
+
+    func setRestoreContinuation(_ continuation: CheckedContinuation<Bool, Never>) {
+        continuationLock.lock()
+        let orphan = _activeRestoreContinuation
+        _activeRestoreContinuation = continuation
+        continuationLock.unlock()
+        orphan?.resume(returning: false)
+    }
+
+    func takeRestoreContinuation() -> CheckedContinuation<Bool, Never>? {
+        continuationLock.lock()
+        defer { continuationLock.unlock() }
+        let continuation = _activeRestoreContinuation
+        _activeRestoreContinuation = nil
+        return continuation
     }
 
     func clearPendingEvents() {
@@ -190,7 +217,7 @@ public class HeliumPaywallSdkModule: Module {
 
     // Function for JavaScript to provide purchase result
     Function("handlePurchaseResult") { (statusString: String, errorMsg: String?, transactionId: String?, originalTransactionId: String?, productId: String?) in
-      guard let continuation = NativeModuleManager.shared.activePurchaseContinuation else {
+      guard let continuation = NativeModuleManager.shared.takePurchaseContinuation() else {
         print("WARNING: handlePurchaseResult called with no active continuation")
         return
       }
@@ -217,22 +244,16 @@ public class HeliumPaywallSdkModule: Module {
       default:          status = .failed(PurchaseError.unknownStatus(status: lowercasedStatus))
       }
 
-      // Clear singleton state
-      NativeModuleManager.shared.clearPurchase()
-
       // Resume the continuation with the status
       continuation.resume(returning: status)
     }
 
     // Function for JavaScript to provide restore result
     Function("handleRestoreResult") { (success: Bool) in
-      guard let continuation = NativeModuleManager.shared.activeRestoreContinuation else {
+      guard let continuation = NativeModuleManager.shared.takeRestoreContinuation() else {
         print("WARNING: handleRestoreResult called with no active continuation")
         return
       }
-
-      // Clear singleton state
-      NativeModuleManager.shared.clearRestore()
 
       continuation.resume(returning: success)
     }
@@ -570,14 +591,8 @@ private class InternalDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTran
         // Clear previous transaction result
         NativeModuleManager.shared.latestTransactionResult = nil
 
-        // Clean up any orphaned continuation
-        if let existingContinuation = NativeModuleManager.shared.activePurchaseContinuation {
-            existingContinuation.resume(returning: .cancelled)
-            NativeModuleManager.shared.clearPurchase()
-        }
-
         return await withCheckedContinuation { continuation in
-            NativeModuleManager.shared.activePurchaseContinuation = continuation
+            NativeModuleManager.shared.setPurchaseContinuation(continuation)
 
             NativeModuleManager.shared.safeSendEvent(eventName: "onDelegateActionEvent", eventData: [
                 "type": "purchase",
@@ -587,14 +602,8 @@ private class InternalDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTran
     }
 
     public func restorePurchases() async -> Bool {
-        // Clean up any orphaned continuation
-        if let existingContinuation = NativeModuleManager.shared.activeRestoreContinuation {
-            existingContinuation.resume(returning: false)
-            NativeModuleManager.shared.clearRestore()
-        }
-
         return await withCheckedContinuation { continuation in
-            NativeModuleManager.shared.activeRestoreContinuation = continuation
+            NativeModuleManager.shared.setRestoreContinuation(continuation)
 
             NativeModuleManager.shared.safeSendEvent(eventName: "onDelegateActionEvent", eventData: [
                 "type": "restore"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase/restore bridging and async continuation handling on both iOS and Android; concurrency mistakes here could cause hangs, double-resumes, or missed purchase results.
> 
> **Overview**
> **Hardens thread-safety around purchase/restore bridging.** Both iOS and Android replace the previous “single mutable continuation” approach with locked `set*`/`take*` continuation accessors that atomically swap and clear the active continuation.
> 
> This also changes lifecycle behavior: orphaned in-flight purchase/restore continuations are now explicitly cancelled when replaced, cancellation handlers only clear *their own* continuation (avoiding wiping a newer one), and `handlePurchaseResult`/`handleRestoreResult` now warn and no-op when invoked without an active continuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bade2ec9c2688809cbd139c0d65840c343fca979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->