### PR TITLE
Hel 5136 paddle

### DIFF
--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -566,21 +566,6 @@ class HeliumPaywallSdkModule : Module() {
       }
     }
 
-    // iOS-only. No-op on Android.
-    Function("enableExternalWebCheckout") { _: String, _: String, _: List<String>? ->
-      // External Web Checkout is iOS-only for now.
-    }
-
-    // iOS-only. No-op on Android.
-    Function("disableExternalWebCheckout") {
-      // External Web Checkout is iOS-only for now.
-    }
-
-    // iOS-only. No-op on Android.
-    Function("setAllowWebCheckoutWithoutUserId") { _: Boolean ->
-      // External Web Checkout is iOS-only for now.
-    }
-
     // Set light/dark mode override
     Function("setLightDarkModeOverride") { mode: String ->
       val heliumMode: HeliumLightDarkMode = when (mode.lowercase()) {

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -566,6 +566,21 @@ class HeliumPaywallSdkModule : Module() {
       }
     }
 
+    // iOS-only. No-op on Android.
+    Function("enableExternalWebCheckout") { _: String, _: String, _: List<String>? ->
+      // External Web Checkout is iOS-only for now.
+    }
+
+    // iOS-only. No-op on Android.
+    Function("disableExternalWebCheckout") {
+      // External Web Checkout is iOS-only for now.
+    }
+
+    // iOS-only. No-op on Android.
+    Function("setAllowWebCheckoutWithoutUserId") { _: Boolean ->
+      // External Web Checkout is iOS-only for now.
+    }
+
     // Set light/dark mode override
     Function("setLightDarkModeOverride") { mode: String ->
       val heliumMode: HeliumLightDarkMode = when (mode.lowercase()) {

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -566,6 +566,46 @@ class HeliumPaywallSdkModule : Module() {
       }
     }
 
+    // iOS-only for now. No-op on Android.
+    Function("enableExternalWebCheckout") { _: String, _: String, _: List<String>? ->
+    }
+
+    // iOS-only for now. No-op on Android.
+    Function("disableExternalWebCheckout") {
+    }
+
+    // iOS-only for now. No-op on Android.
+    Function("setAllowWebCheckoutWithoutUserId") { _: Boolean ->
+    }
+
+    // iOS-only for now. No-op on Android.
+    AsyncFunction("hasActiveStripeEntitlement") Coroutine { ->
+      return@Coroutine false
+    }
+
+    // iOS-only for now. No-op on Android.
+    AsyncFunction("hasActivePaddleEntitlement") Coroutine { ->
+      return@Coroutine false
+    }
+
+    // iOS-only for now. No-op on Android.
+    AsyncFunction("createStripePortalSession") Coroutine { _: String ->
+      return@Coroutine ""
+    }
+
+    // iOS-only for now. No-op on Android.
+    Function("resetStripeEntitlements") {
+    }
+
+    // iOS-only for now. No-op on Android.
+    AsyncFunction("createPaddlePortalSession") Coroutine { ->
+      return@Coroutine ""
+    }
+
+    // iOS-only for now. No-op on Android.
+    Function("resetPaddleEntitlements") {
+    }
+
     // Set light/dark mode override
     Function("setLightDarkModeOverride") { mode: String ->
       val heliumMode: HeliumLightDarkMode = when (mode.lowercase()) {

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -445,6 +445,32 @@ public class HeliumPaywallSdkModule: Module {
       Helium.config.allowWebCheckoutWithoutUserId = allow
     }
 
+    AsyncFunction("hasActiveStripeEntitlement") {
+      return await Helium.entitlements.hasActiveStripeEntitlement()
+    }
+
+    AsyncFunction("hasActivePaddleEntitlement") {
+      return await Helium.entitlements.hasActivePaddleEntitlement()
+    }
+
+    AsyncFunction("createStripePortalSession") { (returnUrl: String) -> String in
+      let url = try await Helium.shared.createStripePortalSession(returnUrl: returnUrl)
+      return url.absoluteString
+    }
+
+    Function("resetStripeEntitlements") {
+      Helium.shared.resetStripeEntitlements()
+    }
+
+    AsyncFunction("createPaddlePortalSession") { () -> String in
+      let url = try await Helium.shared.createPaddlePortalSession()
+      return url.absoluteString
+    }
+
+    Function("resetPaddleEntitlements") {
+      Helium.shared.resetPaddleEntitlements()
+    }
+
     // Enables the module to be used as a native view. Definition components that are accepted as part of the
     // view definition: Prop, Events.
     View(HeliumPaywallSdkView.self) {

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -414,6 +414,37 @@ public class HeliumPaywallSdkModule: Module {
       Helium.config.lightDarkModeOverride = heliumMode
     }
 
+    Function("enableExternalWebCheckout") { (successURL: String, cancelURL: String, paymentProcessors: [String]?) in
+      let processors: WebCheckoutProcessors
+      if let paymentProcessors {
+        var set: WebCheckoutProcessors = []
+        for p in paymentProcessors {
+          switch p.lowercased() {
+          case "paddle": set.insert(.paddle)
+          case "stripe": set.insert(.stripe)
+          default:
+            print("[Helium] enableExternalWebCheckout: unknown payment processor '\(p)', ignoring")
+          }
+        }
+        processors = set
+      } else {
+        processors = .all
+      }
+      Helium.config.enableExternalWebCheckout(
+        successURL: successURL,
+        cancelURL: cancelURL,
+        paymentProcessors: processors
+      )
+    }
+
+    Function("disableExternalWebCheckout") {
+      Helium.config.disableExternalWebCheckout()
+    }
+
+    Function("setAllowWebCheckoutWithoutUserId") { (allow: Bool) in
+      Helium.config.allowWebCheckoutWithoutUserId = allow
+    }
+
     // Enables the module to be used as a native view. Definition components that are accepted as part of the
     // view definition: Prop, Events.
     View(HeliumPaywallSdkView.self) {

--- a/packages/stripe/android/src/main/java/expo/modules/stripesdk/HeliumStripeSdkModule.kt
+++ b/packages/stripe/android/src/main/java/expo/modules/stripesdk/HeliumStripeSdkModule.kt
@@ -13,15 +13,5 @@ class HeliumStripeSdkModule : Module() {
         Function("initializeStripe") { _: Map<String, Any> -> }
 
         Function("setUserIdAndSyncStripeIfNeeded") { _: String -> }
-
-        Function("resetStripeEntitlements") { _: Boolean -> }
-
-        AsyncFunction("createStripePortalSession") { _: String ->
-            ""
-        }
-
-        AsyncFunction("hasActiveStripeEntitlement") {
-            false
-        }
     }
 }

--- a/packages/stripe/ios/HeliumStripeSdkModule.swift
+++ b/packages/stripe/ios/HeliumStripeSdkModule.swift
@@ -37,18 +37,5 @@ public class HeliumStripeSdkModule: Module {
         Function("setUserIdAndSyncStripeIfNeeded") { (userId: String) in
             Helium.shared.setUserIdAndSyncStripeIfNeeded(userId: userId)
         }
-
-        Function("resetStripeEntitlements") { (clearUserId: Bool) in
-            Helium.shared.resetStripeEntitlements(clearUserId: clearUserId)
-        }
-
-        AsyncFunction("createStripePortalSession") { (returnUrl: String) in
-            let url = try await Helium.shared.createStripePortalSession(returnUrl: returnUrl)
-            return url.absoluteString
-        }
-
-        AsyncFunction("hasActiveStripeEntitlement") {
-            return await Helium.shared.hasActiveStripeEntitlement()
-        }
     }
 }

--- a/packages/stripe/src/HeliumStripeSdkModule.ts
+++ b/packages/stripe/src/HeliumStripeSdkModule.ts
@@ -4,12 +4,6 @@ declare class HeliumStripeSdkModule extends NativeModule {
   initializeStripe(config: Record<string, any>): void;
 
   setUserIdAndSyncStripeIfNeeded(userId: string): void;
-
-  resetStripeEntitlements(clearUserId: boolean): void;
-
-  createStripePortalSession(returnUrl: string): Promise<string>;
-
-  hasActiveStripeEntitlement(): Promise<boolean>;
 }
 
 export default requireNativeModule<HeliumStripeSdkModule>("HeliumStripeSdk");

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -42,32 +42,3 @@ export function setUserIdAndSyncStripeIfNeeded(userId: string): void {
     }
     HeliumStripeSdkModule.setUserIdAndSyncStripeIfNeeded(userId);
 }
-
-export function resetStripeEntitlements(clearUserId: boolean = false): void {
-    if (Platform.OS !== 'ios') {
-        console.log('[HeliumStripe] resetStripeEntitlements is only available on iOS');
-        return;
-    }
-    HeliumStripeSdkModule.resetStripeEntitlements(clearUserId);
-}
-
-export async function createStripePortalSession(returnUrl: string): Promise<string | undefined> {
-    if (Platform.OS !== 'ios') {
-        console.log('[HeliumStripe] createStripePortalSession is only available on iOS');
-        return undefined;
-    }
-    try {
-        return await HeliumStripeSdkModule.createStripePortalSession(returnUrl);
-    } catch (error) {
-        console.log('[HeliumStripe] could not create Stripe portal session');
-        return undefined;
-    }
-}
-
-export async function hasActiveStripeEntitlement(): Promise<boolean> {
-    if (Platform.OS !== 'ios') {
-        console.log('[HeliumStripe] hasActiveStripeEntitlement is only available on iOS');
-        return false;
-    }
-    return HeliumStripeSdkModule.hasActiveStripeEntitlement();
-}

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -97,6 +97,7 @@ export type HeliumPurchaseResult = {
 export type HeliumDownloadStatus = 'downloadSuccess' | 'downloadFailure' | 'inProgress' | 'notDownloadedYet';
 export type HeliumLightDarkMode = 'light' | 'dark' | 'system';
 export type HeliumEnvironment = 'sandbox' | 'production';
+export type WebCheckoutProcessor = 'paddle' | 'stripe';
 
 // --- Purchase Configuration Types ---
 

--- a/src/HeliumPaywallSdkModule.ts
+++ b/src/HeliumPaywallSdkModule.ts
@@ -7,6 +7,7 @@ import {
   HeliumPaywallSdkModuleEvents,
   HeliumTransactionStatus,
   NativeHeliumConfig,
+  WebCheckoutProcessor,
 } from "./HeliumPaywallSdk.types";
 
 interface PaywallInfoResult {
@@ -94,7 +95,7 @@ declare class HeliumPaywallSdkModule extends NativeModule<HeliumPaywallSdkModule
   enableExternalWebCheckout(
     successURL: string,
     cancelURL: string,
-    paymentProcessors?: string[],
+    paymentProcessors?: WebCheckoutProcessor[],
   ): void;
 
   disableExternalWebCheckout(): void;

--- a/src/HeliumPaywallSdkModule.ts
+++ b/src/HeliumPaywallSdkModule.ts
@@ -90,6 +90,16 @@ declare class HeliumPaywallSdkModule extends NativeModule<HeliumPaywallSdkModule
   getExperimentInfoForTrigger(trigger: string): ExperimentInfoResult;
 
   setLightDarkModeOverride(mode: HeliumLightDarkMode): void;
+
+  enableExternalWebCheckout(
+    successURL: string,
+    cancelURL: string,
+    paymentProcessors?: string[],
+  ): void;
+
+  disableExternalWebCheckout(): void;
+
+  setAllowWebCheckoutWithoutUserId(allow: boolean): void;
 }
 
 // This call loads the native module object from the JSI.

--- a/src/HeliumPaywallSdkModule.ts
+++ b/src/HeliumPaywallSdkModule.ts
@@ -100,6 +100,18 @@ declare class HeliumPaywallSdkModule extends NativeModule<HeliumPaywallSdkModule
   disableExternalWebCheckout(): void;
 
   setAllowWebCheckoutWithoutUserId(allow: boolean): void;
+
+  hasActiveStripeEntitlement(): Promise<boolean>;
+
+  hasActivePaddleEntitlement(): Promise<boolean>;
+
+  createStripePortalSession(returnUrl: string): Promise<string>;
+
+  resetStripeEntitlements(): void;
+
+  createPaddlePortalSession(): Promise<string>;
+
+  resetPaddleEntitlements(): void;
 }
 
 // This call loads the native module object from the JSI.

--- a/src/index.ts
+++ b/src/index.ts
@@ -517,6 +517,10 @@ export const enableExternalWebCheckout = ({
   cancelURL: string;
   paymentProcessors?: WebCheckoutProcessor[];
 }): void => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] enableExternalWebCheckout is only available on iOS');
+    return;
+  }
   try {
     HeliumPaywallSdkModule.enableExternalWebCheckout(successURL, cancelURL, paymentProcessors);
   } catch (e) {
@@ -532,6 +536,10 @@ export const enableExternalWebCheckout = ({
  * their entitlements but is not guaranteed to do so.
  */
 export const disableExternalWebCheckout = (): void => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] disableExternalWebCheckout is only available on iOS');
+    return;
+  }
   try {
     HeliumPaywallSdkModule.disableExternalWebCheckout();
   } catch (e) {
@@ -556,10 +564,121 @@ export const disableExternalWebCheckout = (): void => {
  * Defaults to `false`.
  */
 export const setAllowWebCheckoutWithoutUserId = (allow: boolean): void => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] setAllowWebCheckoutWithoutUserId is only available on iOS');
+    return;
+  }
   try {
     HeliumPaywallSdkModule.setAllowWebCheckoutWithoutUserId(allow);
   } catch (e) {
     console.error('[Helium] setAllowWebCheckoutWithoutUserId error', e);
+  }
+};
+
+/**
+ * iOS only. Returns `true` if the user has any active Stripe entitlement.
+ */
+export const hasActiveStripeEntitlement = async (): Promise<boolean> => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] hasActiveStripeEntitlement is only available on iOS');
+    return false;
+  }
+  try {
+    return await HeliumPaywallSdkModule.hasActiveStripeEntitlement();
+  } catch (e) {
+    console.error('[Helium] hasActiveStripeEntitlement error', e);
+    return false;
+  }
+};
+
+/**
+ * iOS only. Returns `true` if the user has any active Paddle entitlement.
+ */
+export const hasActivePaddleEntitlement = async (): Promise<boolean> => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] hasActivePaddleEntitlement is only available on iOS');
+    return false;
+  }
+  try {
+    return await HeliumPaywallSdkModule.hasActivePaddleEntitlement();
+  } catch (e) {
+    console.error('[Helium] hasActivePaddleEntitlement error', e);
+    return false;
+  }
+};
+
+/**
+ * iOS only. Creates a Stripe Customer Portal session and returns the portal URL.
+ * The host app can open this URL in a browser or in-app webview to let the user
+ * manage their subscriptions, payment methods, and invoices.
+ *
+ * @param returnUrl The URL Stripe redirects to after the user finishes in the portal.
+ * @returns The portal session URL, or `undefined` if the session could not be created.
+ */
+export const createStripePortalSession = async (returnUrl: string): Promise<string | undefined> => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] createStripePortalSession is only available on iOS');
+    return undefined;
+  }
+  try {
+    return await HeliumPaywallSdkModule.createStripePortalSession(returnUrl);
+  } catch (e) {
+    console.error('[Helium] createStripePortalSession error', e);
+    return undefined;
+  }
+};
+
+/**
+ * iOS only. Resets Stripe entitlements and clears the user ID.
+ * If your app can support multiple Stripe users on the same device, call this to effectively
+ * "log out" a Stripe user.
+ */
+export const resetStripeEntitlements = (): void => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] resetStripeEntitlements is only available on iOS');
+    return;
+  }
+  try {
+    HeliumPaywallSdkModule.resetStripeEntitlements();
+  } catch (e) {
+    console.error('[Helium] resetStripeEntitlements error', e);
+  }
+};
+
+/**
+ * iOS only. Creates a Paddle Customer Portal session for the current user and returns the
+ * portal URL. The host app can open this URL in a browser or in-app webview to let the user
+ * manage their subscriptions.
+ *
+ * @returns The portal session URL, or `undefined` if the session could not be created.
+ */
+export const createPaddlePortalSession = async (): Promise<string | undefined> => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] createPaddlePortalSession is only available on iOS');
+    return undefined;
+  }
+  try {
+    return await HeliumPaywallSdkModule.createPaddlePortalSession();
+  } catch (e) {
+    console.error('[Helium] createPaddlePortalSession error', e);
+    return undefined;
+  }
+};
+
+/**
+ * iOS only. Resets Paddle entitlements and clears the user ID.
+ * If your app can support multiple Paddle users on the same device, call this to effectively
+ * "log out" a Paddle user.
+ */
+export const resetPaddleEntitlements = (): void => {
+  if (Platform.OS !== 'ios') {
+    console.log('[Helium] resetPaddleEntitlements is only available on iOS');
+    return;
+  }
+  try {
+    HeliumPaywallSdkModule.resetPaddleEntitlements();
+  } catch (e) {
+    console.error('[Helium] resetPaddleEntitlements error', e);
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   HeliumPaywallEvent,
   NativeHeliumConfig, PaywallEventHandlers, PaywallInfo, PresentUpsellParams,
   ResetHeliumOptions,
+  WebCheckoutProcessor,
 } from "./HeliumPaywallSdk.types";
 import { ExperimentInfo } from "./HeliumExperimentInfo.types";
 import HeliumPaywallSdkModule from "./HeliumPaywallSdkModule";
@@ -450,7 +451,8 @@ export const hasAnyEntitlement = HeliumPaywallSdkModule.hasAnyEntitlement;
 export const resetHelium = async (options?: ResetHeliumOptions): Promise<void> => {
   paywallEventHandlers = undefined;
   presentOnPaywallUnavailable = undefined;
-  presentOnEntitled = undefined;
+  presentOnEntitled = undefined; //oof if you call while another paywall open these can get replaced...
+  //should either return early in presentupsell or be more robust and make these live per-presentation
   removeAllHeliumListeners();
 
   try {
@@ -490,6 +492,76 @@ export const disableRestoreFailedDialog = HeliumPaywallSdkModule.disableRestoreF
  * dark mode setting. Set `"userInterfaceStyle": "automatic"` for 'system' to work correctly.
  */
 export const setLightDarkModeOverride = HeliumPaywallSdkModule.setLightDarkModeOverride;
+
+/**
+ * iOS only. Enables External Web Checkout Flow for any Paddle or Stripe products in your paywalls.
+ * If not enabled, paywalls with Paddle/Stripe products will not show. Your fallback paywall/s,
+ * if provided, will show instead.
+ *
+ * You must provide redirect URLs so Helium knows where to send the user after checkout completes
+ * or is cancelled.
+ *
+ * @param successURL The URL to redirect to after a successful payment.
+ *   Include `{CHECKOUT_SESSION_ID}` in the URL to receive the session ID.
+ * @param cancelURL The URL the provider redirects to when the user cancels checkout.
+ * @param paymentProcessors Which payment processors to enable. Defaults to both Paddle and Stripe.
+ *   Pass `['paddle']` or `['stripe']` if your app only uses one to skip the unused processor's
+ *   entitlement network calls.
+ */
+export const enableExternalWebCheckout = ({
+                                            successURL,
+                                            cancelURL,
+                                            paymentProcessors,
+                                          }: {
+  successURL: string;
+  cancelURL: string;
+  paymentProcessors?: WebCheckoutProcessor[];
+}): void => {
+  try {
+    HeliumPaywallSdkModule.enableExternalWebCheckout(successURL, cancelURL, paymentProcessors);
+  } catch (e) {
+    console.error('[Helium] enableExternalWebCheckout error', e);
+  }
+};
+
+/**
+ * iOS only. Disables External Web Checkout Flow. Paywalls with Paddle or Stripe products
+ * will not show. Your fallback paywall/s, if provided, will show instead.
+ *
+ * NOTE - if you have existing Paddle/Stripe customers, Helium will attempt to continue respecting
+ * their entitlements but is not guaranteed to do so.
+ */
+export const disableExternalWebCheckout = (): void => {
+  try {
+    HeliumPaywallSdkModule.disableExternalWebCheckout();
+  } catch (e) {
+    console.error('[Helium] disableExternalWebCheckout error', e);
+  }
+};
+
+/**
+ * iOS only. Allows Web Checkout paywalls (Paddle/Stripe) to show even when no custom user ID
+ * has been set via `setCustomUserId`.
+ *
+ * By default, paywalls with Paddle or Stripe products will not show if user ID is not set.
+ * Your fallback paywall/s, if provided, will show instead.
+ * Set this to `true` if your app supports purchase-before-signup flows. Once `setCustomUserId`
+ * is called later, Helium will automatically link the Paddle/Stripe customer to that user ID.
+ *
+ * Warning: Use with caution. If the user purchases via web checkout and your app never sets a
+ * `customUserId` (or uninstalls the app before doing so), the purchase may be unrecoverable for
+ * that user. Only enable this if your app has a clear path for the user to set a custom user ID
+ * post-purchase.
+ *
+ * Defaults to `false`.
+ */
+export const setAllowWebCheckoutWithoutUserId = (allow: boolean): void => {
+  try {
+    HeliumPaywallSdkModule.setAllowWebCheckoutWithoutUserId(allow);
+  } catch (e) {
+    console.error('[Helium] setAllowWebCheckoutWithoutUserId error', e);
+  }
+};
 
 /**
  * Get experiment allocation info for a specific trigger

--- a/src/index.ts
+++ b/src/index.ts
@@ -451,8 +451,7 @@ export const hasAnyEntitlement = HeliumPaywallSdkModule.hasAnyEntitlement;
 export const resetHelium = async (options?: ResetHeliumOptions): Promise<void> => {
   paywallEventHandlers = undefined;
   presentOnPaywallUnavailable = undefined;
-  presentOnEntitled = undefined; //oof if you call while another paywall open these can get replaced...
-  //should either return early in presentupsell or be more robust and make these live per-presentation
+  presentOnEntitled = undefined;
   removeAllHeliumListeners();
 
   try {
@@ -519,6 +518,10 @@ export const enableExternalWebCheckout = ({
 }): void => {
   if (Platform.OS !== 'ios') {
     console.log('[Helium] enableExternalWebCheckout is only available on iOS');
+    return;
+  }
+  if (paymentProcessors && paymentProcessors.length === 0) {
+    console.error("[Helium] enableExternalWebCheckout: paymentProcessors must not be empty. Omit it to enable all, or pass ['paddle'] or ['stripe'].");
     return;
   }
   try {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new iOS-facing APIs for external web checkout configuration and Paddle/Stripe entitlement/portal management, which touches billing-related flows. Android stubs are no-ops, but iOS behavior changes could affect paywall visibility and entitlement correctness if misconfigured.
> 
> **Overview**
> Adds an iOS-only External Web Checkout configuration surface to the main `HeliumPaywallSdk` module, including `enableExternalWebCheckout` (success/cancel redirect URLs + optional processor selection) and `disableExternalWebCheckout`, plus a toggle to allow checkout without a custom user ID.
> 
> Introduces iOS-only Paddle/Stripe utilities on `HeliumPaywallSdk`: entitlement status checks, customer portal session creation, and entitlement reset functions, with Android implemented as explicit no-ops/default returns for API parity.
> 
> Removes the previously-exposed Stripe entitlement/portal APIs from the separate `expo-helium-stripe` module (native + TS), consolidating those capabilities into the main SDK API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b68f43db551f88324405b59a0d22cc9686e8be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external web checkout controls (enable/disable, success/cancel URLs, optional processor selection) and option to allow checkout without a user ID.
  * Added entitlement status checks for Stripe and Paddle, portal session creation, and entitlement reset operations.

* **Breaking Changes**
  * Stripe-specific entitlement/portal APIs consolidated into the main paywall SDK module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->