### PR TITLE
HEL-5225 add paddle purchase sync support to RevenueCat handler

### DIFF
--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -70,7 +70,12 @@ export type HeliumPaywallEvent = {
   customPaywallActionParams?: Record<string, any>;
   /** Transaction ID for a successful purchase. */
   canonicalJoinTransactionId?: string;
+  /** Payment processor that completed a successful purchase. Present on `purchaseSucceeded` events. */
+  paymentProcessor?: HeliumPaymentProcessor;
 };
+
+/** Identifies which payment processor completed a purchase. */
+export type HeliumPaymentProcessor = 'appStore' | 'stripe' | 'paddle';
 export type DelegateActionEvent = {
   type: 'purchase' | 'restore';
   productId?: string;
@@ -272,6 +277,7 @@ export interface PurchaseSucceededEvent {
   triggerName: string;
   paywallName: string;
   isSecondTry: boolean;
+  paymentProcessor?: HeliumPaymentProcessor;
 }
 
 export interface PaywallOpenFailedEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,6 +316,7 @@ function callPaywallEventHandlers(event: HeliumPaywallEvent) {
           triggerName: event.triggerName ?? 'unknown',
           paywallName: event.paywallName ?? 'unknown',
           isSecondTry: event.isSecondTry ?? false,
+          paymentProcessor: event.paymentProcessor,
         });
         break;
       case 'paywallOpenFailed':

--- a/src/revenuecat/revenuecat.ts
+++ b/src/revenuecat/revenuecat.ts
@@ -18,6 +18,8 @@ export interface RevenueCatConfig {
   apiKeyAndroid?: string;
   /** Set to true to disable automatic RevenueCat entitlement syncing after Stripe purchases. */
   disableStripePurchaseSync?: boolean;
+  /** Set to true to disable automatic RevenueCat entitlement syncing after Paddle purchases. */
+  disablePaddlePurchaseSync?: boolean;
 }
 
 export function createRevenueCatPurchaseConfig(config?: RevenueCatConfig): HeliumPurchaseConfig {
@@ -43,11 +45,13 @@ type PurchaseAttemptResult = HeliumPurchaseResult & { shouldRetry?: boolean };
 
 export class RevenueCatHeliumHandler {
   private stripePurchaseSyncDisabled: boolean = false;
-  private isSyncingStripePurchase: boolean = false;
+  private paddlePurchaseSyncDisabled: boolean = false;
+  private isSyncingThirdPartyPayment: boolean = false;
   private setUpPromise: Promise<void>;
 
   constructor(config?: RevenueCatConfig) {
     this.stripePurchaseSyncDisabled = config?.disableStripePurchaseSync ?? false;
+    this.paddlePurchaseSyncDisabled = config?.disablePaddlePurchaseSync ?? false;
 
     // Determine which API key to use based on platform
     let effectiveApiKey: string | undefined;
@@ -279,33 +283,35 @@ export class RevenueCatHeliumHandler {
   }
 
   onHeliumEvent(event: HeliumPaywallEvent): void {
-    if (!this.stripePurchaseSyncDisabled && event.type === 'purchaseSucceeded' && this.isStripePurchase(event)) {
-      void this.syncRevenueCatAfterStripePurchase();
+    if (event.type === 'purchaseSucceeded' && this.shouldSyncAfterThirdPartyPayment(event)) {
+      void this.syncRevenueCatAfterThirdPartyPayment();
     }
   }
 
-  private isStripePurchase(event: HeliumPaywallEvent): boolean {
-    if (event.canonicalJoinTransactionId?.startsWith('si_')) {
-      return true;
+  private shouldSyncAfterThirdPartyPayment(event: HeliumPaywallEvent): boolean {
+    switch (event.paymentProcessor) {
+      case 'stripe':
+        return !this.stripePurchaseSyncDisabled;
+      case 'paddle':
+        return !this.paddlePurchaseSyncDisabled;
+      default:
+        return false;
     }
-    if (event.productId && /^prod_\w+:price_\w+$/.test(event.productId)) {
-      return true;
-    }
-    return false;
   }
 
   /**
-   * After a Stripe purchase completes, the RevenueCat SDK on-device has no way to
-   * know that a new entitlement exists until its backend processes the Stripe webhook.
-   * Without this, RevenueCat customer info would remain stale until the next app launch
-   * or natural refresh. This method polls RevenueCat with progressive backoff to force
-   * a customer info refresh, stopping early if the update listener fires (~50s max).
+   * After a third-party payment (Stripe or Paddle) completes, the RevenueCat SDK
+   * on-device has no way to know that a new entitlement exists until its backend
+   * processes the provider webhook. Without this, RevenueCat customer info would
+   * remain stale until the next app launch or natural refresh. This method polls
+   * RevenueCat with progressive backoff to force a customer info refresh, stopping
+   * early if the update listener fires (~50s max).
    */
-  private async syncRevenueCatAfterStripePurchase(): Promise<void> {
-    if (this.isSyncingStripePurchase) {
+  private async syncRevenueCatAfterThirdPartyPayment(): Promise<void> {
+    if (this.isSyncingThirdPartyPayment) {
       return;
     }
-    this.isSyncingStripePurchase = true;
+    this.isSyncingThirdPartyPayment = true;
 
     let synced = false;
     let hasInvalidatedCache = false;
@@ -338,7 +344,7 @@ export class RevenueCatHeliumHandler {
       await pollPhase(2, 15000);  // Phase 3: every 15s for 2 attempts
     } finally {
       Purchases.removeCustomerInfoUpdateListener(listener);
-      this.isSyncingStripePurchase = false;
+      this.isSyncingThirdPartyPayment = false;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies the RevenueCat post-purchase syncing trigger logic and adds Paddle handling; incorrect processor tagging or sync gating could leave entitlements stale after third-party purchases.
> 
> **Overview**
> Adds a `paymentProcessor` field (new `HeliumPaymentProcessor` union) to `purchaseSucceeded`/`HeliumPaywallEvent` payloads and forwards it through `callPaywallEventHandlers`.
> 
> Extends the RevenueCat purchase handler config with `disablePaddlePurchaseSync` and generalizes the post-purchase polling refresh from Stripe-only to Stripe-or-Paddle based on `event.paymentProcessor`, with a shared in-flight guard to avoid concurrent sync attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4d90a10628dfd239858b81aa4101160d33989d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->