### PR TITLE
hel 5503 expo purchase/restore overrides

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  implementation("com.tryhelium.paywall:core:4.4.4")
+  implementation("com.tryhelium.paywall:core:4.4.5")
   implementation("com.google.code.gson:gson:2.10.1")
   implementation("com.android.billingclient:billing:8.0.0")
 }

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -616,18 +616,32 @@ class HeliumPaywallSdkModule : Module() {
     Function("resetPaddleEntitlements") {
     }
 
-    // Testing stubs — bridge signatures must match iOS so positional args line up.
-    // No-op until the Android Helium SDK ships its testing API.
-    Function("setTestPurchaseResult") { _: String ->
+    // Testing stubs. See Helium.testing in the Android SDK.
+    Function("setTestPurchaseResult") { result: String ->
+      val status: HeliumPaywallTransactionStatus = when (result.lowercase()) {
+        "purchased" -> HeliumPaywallTransactionStatus.Purchased
+        "cancelled" -> HeliumPaywallTransactionStatus.Cancelled
+        "restored" -> HeliumPaywallTransactionStatus.Purchased  // Android SDK has no Restored, map to Purchased
+        "pending" -> HeliumPaywallTransactionStatus.Pending
+        "failed" -> HeliumPaywallTransactionStatus.Failed(Exception("Stubbed test failure."))
+        else -> {
+          android.util.Log.w("HeliumPaywallSdk", "setTestPurchaseResult: unknown result '$result', ignoring")
+          return@Function
+        }
+      }
+      Helium.testing.purchaseHandler = { _ -> status }
     }
 
-    Function("setTestRestoreResult") { _: Boolean ->
+    Function("setTestRestoreResult") { success: Boolean ->
+      Helium.testing.restoreHandler = { success }
     }
 
-    Function("setTestIntroOfferEligibility") { _: Boolean ->
+    Function("setTestIntroOfferEligibility") { eligible: Boolean ->
+      Helium.testing.introOfferEligibility = { _ -> eligible }
     }
 
     Function("resetTesting") {
+      Helium.testing.reset()
     }
 
     // Set light/dark mode override

--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -616,6 +616,20 @@ class HeliumPaywallSdkModule : Module() {
     Function("resetPaddleEntitlements") {
     }
 
+    // Testing stubs — bridge signatures must match iOS so positional args line up.
+    // No-op until the Android Helium SDK ships its testing API.
+    Function("setTestPurchaseResult") { _: String ->
+    }
+
+    Function("setTestRestoreResult") { _: Boolean ->
+    }
+
+    Function("setTestIntroOfferEligibility") { _: Boolean ->
+    }
+
+    Function("resetTesting") {
+    }
+
     // Set light/dark mode override
     Function("setLightDarkModeOverride") { mode: String ->
       val heliumMode: HeliumLightDarkMode = when (mode.lowercase()) {

--- a/ios/HeliumPaywallSdk.podspec
+++ b/ios/HeliumPaywallSdk.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'Helium', '4.4.9'
+  s.dependency 'Helium', '4.5.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -488,8 +488,6 @@ public class HeliumPaywallSdkModule: Module {
     }
 
     // MARK: - Testing
-    // TODO: requires helium-swift version that ships `Helium.testing`. Will not
-    // compile against earlier versions — bump the Podfile dep when this lands.
 
     Function("setTestPurchaseResult") { (result: String) in
       let status: HeliumPaywallTransactionStatus

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -483,6 +483,37 @@ public class HeliumPaywallSdkModule: Module {
       Helium.shared.resetPaddleEntitlements()
     }
 
+    // MARK: - Testing
+    // TODO: requires helium-swift version that ships `Helium.testing`. Will not
+    // compile against earlier versions — bump the Podfile dep when this lands.
+
+    Function("setTestPurchaseResult") { (result: String) in
+      let status: HeliumPaywallTransactionStatus
+      switch result.lowercased() {
+      case "purchased": status = .purchased
+      case "cancelled": status = .cancelled
+      case "restored":  status = .restored
+      case "pending":   status = .pending
+      case "failed":    status = .failed(PurchaseError.purchaseFailed(errorMsg: "Stubbed test failure."))
+      default:
+        print("[Helium] heliumTesting.setPurchaseResult: unknown result '\(result)', ignoring")
+        return
+      }
+      Helium.testing.purchaseHandler = { _ in status }
+    }
+
+    Function("setTestRestoreResult") { (success: Bool) in
+      Helium.testing.restoreHandler = { success }
+    }
+
+    Function("setTestIntroOfferEligibility") { (eligible: Bool) in
+      Helium.testing.introOfferEligibility = { _ in eligible }
+    }
+
+    Function("resetTesting") {
+      Helium.testing.reset()
+    }
+
     // Enables the module to be used as a native view. Definition components that are accepted as part of the
     // view definition: Prop, Events.
     View(HeliumPaywallSdkView.self) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-helium",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Helium paywalls expo sdk",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/HeliumPaywallSdkModule.ts
+++ b/src/HeliumPaywallSdkModule.ts
@@ -117,6 +117,14 @@ declare class HeliumPaywallSdkModule extends NativeModule<HeliumPaywallSdkModule
   createPaddlePortalSession(): Promise<string>;
 
   resetPaddleEntitlements(): void;
+
+  setTestPurchaseResult(result: HeliumTransactionStatus): void;
+
+  setTestRestoreResult(success: boolean): void;
+
+  setTestIntroOfferEligibility(eligible: boolean): void;
+
+  resetTesting(): void;
 }
 
 // This call loads the native module object from the JSI.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   HeliumConfig,
   HeliumLogEvent,
   HeliumPaywallEvent,
+  HeliumTransactionStatus,
   NativeHeliumConfig, PaywallEventHandlers, PaywallInfo, PresentUpsellParams,
   ResetHeliumOptions,
   WebCheckoutProcessor,
@@ -821,5 +822,65 @@ function convertValueBooleansToMarkers(value: any): any {
   }
   return value;
 }
+
+/**
+ * Stubs for automated testing (UI tests, CI, EAS builds where StoreKit / Play Billing
+ * configuration is awkward). Gate these calls behind a build-env flag — e.g.
+ * `if (process.env.EXPO_PUBLIC_E2E === 'true') { ... }` — so they never run in
+ * production builds.
+ *
+ * The native SDK additionally ignores test handlers when it detects a production
+ * environment, but the host app should not rely on that safety net.
+ */
+export const heliumTesting = {
+  /**
+   * Stub purchase attempts to return the given result instead of running the real
+   * StoreKit / Play Billing flow. Applies to every product ID.
+   */
+  setPurchaseResult: (result: HeliumTransactionStatus): void => {
+    try {
+      HeliumPaywallSdkModule.setTestPurchaseResult(result);
+    } catch (e) {
+      console.error('[Helium] heliumTesting.setPurchaseResult error', e);
+    }
+  },
+
+  /**
+   * Stub restore attempts to return the given result instead of running the real
+   * restore flow.
+   */
+  setRestoreResult: (success: boolean): void => {
+    try {
+      HeliumPaywallSdkModule.setTestRestoreResult(success);
+    } catch (e) {
+      console.error('[Helium] heliumTesting.setRestoreResult error', e);
+    }
+  },
+
+  /**
+   * Override the intro-offer eligibility check for every product. Useful for testing
+   * the "no trial offer" UI branch, which sandbox accounts can rarely reproduce
+   * without making a real purchase.
+   *
+   * Important: eligibility is read during config fetch and cached, so call this
+   * BEFORE `initialize()` for the initial paywall render to reflect the override.
+   */
+  setIntroOfferEligibility: (eligible: boolean): void => {
+    try {
+      HeliumPaywallSdkModule.setTestIntroOfferEligibility(eligible);
+    } catch (e) {
+      console.error('[Helium] heliumTesting.setIntroOfferEligibility error', e);
+    }
+  },
+
+  /** Clear all configured test handlers. Native SDK falls back to real flows. */
+  reset: (): void => {
+    try {
+      HeliumPaywallSdkModule.resetTesting();
+    } catch (e) {
+      console.error('[Helium] heliumTesting.reset error', e);
+    }
+  },
+};
 
 export {createCustomPurchaseConfig, HELIUM_CTA_NAMES} from './HeliumPaywallSdk.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -842,14 +842,11 @@ function convertValueBooleansToMarkers(value: any): any {
  * configuration is awkward). Gate these calls behind a build-env flag — e.g.
  * `if (process.env.EXPO_PUBLIC_E2E === 'true') { ... }` — so they never run in
  * production builds.
- *
- * The native SDK additionally ignores test handlers when it detects a production
- * environment, but the host app should not rely on that safety net.
  */
 export const heliumTesting = {
   /**
    * Stub purchase attempts to return the given result instead of running the real
-   * StoreKit / Play Billing flow. Applies to every product ID.
+   * purchase flow.
    */
   setPurchaseResult: (result: HeliumTransactionStatus): void => {
     try {
@@ -872,12 +869,9 @@ export const heliumTesting = {
   },
 
   /**
-   * Override the intro-offer eligibility check for every product. Useful for testing
-   * the "no trial offer" UI branch, which sandbox accounts can rarely reproduce
-   * without making a real purchase.
+   * Override the intro-offer eligibility check for every product.
    *
-   * Important: eligibility is read during config fetch and cached, so call this
-   * BEFORE `initialize()` for the initial paywall render to reflect the override.
+   * Important: Call this BEFORE `initialize()`.
    */
   setIntroOfferEligibility: (eligible: boolean): void => {
     try {
@@ -887,7 +881,7 @@ export const heliumTesting = {
     }
   },
 
-  /** Clear all configured test handlers. Native SDK falls back to real flows. */
+  /** Clear all configured test handlers. */
   reset: (): void => {
     try {
       HeliumPaywallSdkModule.resetTesting();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase/restore behavior paths via new test hooks; safe if gated to E2E, but misuse in production could bypass real billing.
> 
> **Overview**
> Adds **`heliumTesting`** on the JS side so E2E/CI can stub purchase, restore, and intro-offer eligibility without StoreKit or Play Billing, with native bridge methods on iOS and Android wired to **`Helium.testing`** in the updated native SDKs.
> 
> Bumps **expo-helium** to **3.4.7** and native dependencies (**Helium** iOS **4.5.0**, Android paywall core **4.4.5**). Android maps **`restored`** purchase stubs to **Purchased** because the Android SDK has no restored status. Docs recommend gating these APIs behind something like **`EXPO_PUBLIC_E2E`** so production builds do not call them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c52ed837ded5438a5ff9703598c65ca8c63fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->