### PR TITLE
[HEL-5580] | Expo: Opt presentUpsell into SAME_ACTIVITY

### DIFF
--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -21,6 +21,7 @@ import com.tryhelium.paywall.core.HeliumPaywallTransactionStatus
 import com.tryhelium.paywall.core.HeliumLightDarkMode
 import com.tryhelium.paywall.core.HeliumWrapperSdkConfig
 import com.tryhelium.paywall.core.PaywallPresentationConfig
+import com.tryhelium.paywall.core.PresentationMode
 import com.tryhelium.paywall.delegate.HeliumPaywallDelegate
 import com.tryhelium.paywall.delegate.PlayStorePaywallDelegate
 import com.tryhelium.paywall.core.logger.HeliumLogLevel
@@ -403,7 +404,8 @@ class HeliumPaywallSdkModule : Module() {
           fromActivityContext = activity,
           customPaywallTraits = convertedTraits,
           dontShowIfAlreadyEntitled = dontShowIfAlreadyEntitled ?: false,
-          disableSystemBackNavigation = disableSystemBackNavigation ?: false
+          disableSystemBackNavigation = disableSystemBackNavigation ?: false,
+          presentationMode = PresentationMode.SAME_ACTIVITY
         ),
         onEntitled = {
           NativeModuleManager.safeSendEvent(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Presentation mode affects Android activity/navigation around paywalls, and the change depends on an alpha Helium SDK build.
> 
> **Overview**
> On **Android**, the Expo native module now presents upsells in **`PresentationMode.SAME_ACTIVITY`** when `presentUpsell` calls `Helium.presentPaywall`, instead of relying on the SDK default presentation behavior.
> 
> To support that API, the Helium Android dependency is bumped from **`com.tryhelium.paywall:core:4.4.5`** to **`4.4.6-alpha01`**. No JS/TS API or iOS bridge changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09df6a13024636637edd03223f040506db5aa72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paywall display behavior so upsell screens now open in the current app view, resulting in a more seamless in-app experience.
  * Preserved existing back-navigation behavior while updating how the paywall is presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->