### PR TITLE
[HEL-5785] | Modern build plugin with Pika

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,35 +1,10 @@
-apply plugin: 'com.android.library'
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
 
 group = 'expo.modules.paywallsdk'
 version = '0.1.0'
-
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
-useCoreDependencies()
-useExpoPublishing()
-
-// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
-// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
-// Most of the time, you may like to manage the Android SDK versions yourself.
-def useManagedAndroidSdkVersions = false
-if (useManagedAndroidSdkVersions) {
-  useDefaultAndroidSdkVersions()
-} else {
-  buildscript {
-    // Simple helper that allows the root project to override versions declared by this library.
-    ext.safeExtGet = { prop, fallback ->
-      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-    }
-  }
-  project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
-    defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 21)
-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
-    }
-  }
-}
 
 android {
   namespace "expo.modules.paywallsdk"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-only Gradle refactor with no runtime code changes; risk is mainly if the new plugin applies different SDK defaults than the removed manual block.
> 
> **Overview**
> Migrates the Android module from the legacy ExpoModulesCore Gradle script setup to the **`expo-module-gradle-plugin`** via a modern **`plugins {}`** block (alongside `com.android.library`).
> 
> Removes the old **`apply from` / `applyKotlinExpoModulesCorePlugin` / `useCoreDependencies` / `useExpoPublishing`** wiring and drops the manual **`useManagedAndroidSdkVersions`** branch that set **`compileSdk`**, **`minSdk`**, and **`targetSdk`** through **`safeExtGet`**. The **`android`** block now only keeps namespace, version metadata, and lint options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d479e026a6e0e4ea148bec0226e8d913357aff5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Android build configuration to use modern Gradle plugin syntax standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->