### PR TITLE
[HEL-5951] | Introduced Trigger Expo SDK Update on Release

### DIFF
--- a/.github/workflows/update-android-dependency.yml
+++ b/.github/workflows/update-android-dependency.yml
@@ -1,0 +1,57 @@
+name: Update Android Dependency
+
+on:
+  repository_dispatch:
+    types: [update-android-dependency]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Android SDK version to update to (with or without leading v)'
+        required: true
+        type: string
+
+jobs:
+  update-android-dependency:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Android releases are tagged with a leading v (e.g. v4.4.7) but the
+      # Gradle dependency uses a bare version, so strip the prefix if present.
+      - name: Resolve version
+        id: version
+        env:
+          RAW_VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
+        run: echo "version=${RAW_VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Android SDK dependency
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          sed -i "s/implementation(\"com\.tryhelium\.paywall:core:[^\"]*\")/implementation(\"com.tryhelium.paywall:core:${VERSION}\")/" android/build.gradle
+
+          # Fail loudly if the dependency line was not found, rather than
+          # opening a PR that only bumps package.json.
+          grep -q "com.tryhelium.paywall:core:${VERSION}" android/build.gradle
+
+      - name: Bump package.json version
+        run: npm version patch --no-git-tag-version
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Update helium-android SDK dependency to ${{ steps.version.outputs.version }}"
+          branch: update-android-sdk-${{ steps.version.outputs.version }}
+          title: "Update helium-android SDK to ${{ steps.version.outputs.version }}"
+          body: |
+            Automated update of helium-android SDK dependency to version ${{ steps.version.outputs.version }}.
+
+            Changes:
+            - Updated `android/build.gradle` paywall-core dependency version
+            - Bumped package.json version (patch increment)
+
+            This PR was automatically created by the Android SDK release workflow.

--- a/.github/workflows/update-android-dependency.yml
+++ b/.github/workflows/update-android-dependency.yml
@@ -22,26 +22,52 @@ jobs:
 
       # Android releases are tagged with a leading v (e.g. v4.4.7) but the
       # Gradle dependency uses a bare version, so strip the prefix if present.
+      # Reject anything that is not a version string so an empty or malformed
+      # payload can never reach the sed replacement below.
       - name: Resolve version
         id: version
         env:
           RAW_VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
-        run: echo "version=${RAW_VERSION#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="${RAW_VERSION#v}"
+          VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $VERSION_PATTERN ]]; then
+            echo "::error::'${RAW_VERSION}' is not a valid version"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Update Android SDK dependency
+        id: update
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Match the full coordinate including the closing quote and paren, so
+          # a version that is merely a prefix of the pinned one cannot pass.
+          TARGET="implementation(\"com.tryhelium.paywall:core:${VERSION}\")"
+
+          if grep -qF "$TARGET" android/build.gradle; then
+            echo "Dependency already at ${VERSION}; nothing to update."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           sed -i "s/implementation(\"com\.tryhelium\.paywall:core:[^\"]*\")/implementation(\"com.tryhelium.paywall:core:${VERSION}\")/" android/build.gradle
 
-          # Fail loudly if the dependency line was not found, rather than
-          # opening a PR that only bumps package.json.
-          grep -q "com.tryhelium.paywall:core:${VERSION}" android/build.gradle
+          # If the dependency line was absent or in an unexpected format, fail
+          # the job instead of opening a PR that only bumps package.json.
+          if ! grep -qF "$TARGET" android/build.gradle; then
+            echo "::error::Could not update com.tryhelium.paywall:core in android/build.gradle"
+            exit 1
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Bump package.json version
+        if: steps.update.outputs.changed == 'true'
         run: npm version patch --no-git-tag-version
 
       - name: Create Pull Request
+        if: steps.update.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "Update helium-android SDK dependency to ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions automation; no app runtime, auth, or production logic is modified.
> 
> **Overview**
> Adds a GitHub Actions workflow so **Android SDK releases can automatically open a PR** in this repo to bump the native dependency and npm package version, matching the existing iOS update flow.
> 
> The workflow runs on **`repository_dispatch`** (`update-android-dependency`) or **manual `workflow_dispatch`** with a version. It **normalizes tags** by stripping a leading `v`, **rewrites** `com.tryhelium.paywall:core` in `android/build.gradle`, **verifies** the line was updated (via `grep` so a failed `sed` does not leave a package-only bump), **patches `package.json`**, and opens a PR with `peter-evans/create-pull-request@v7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92369a6b74eeda445065dd38595ac40f5fc59d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to update the Android dependency version and open a pull request when changes are needed.
  * Supports both manual runs and event-based triggers, with version validation and safeguards to avoid unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->