### PR TITLE
[HEL-6403] | onEntitled events to include purchase/restore/already-entitled event as argument

### DIFF
--- a/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
+++ b/android/src/main/java/expo/modules/paywallsdk/HeliumPaywallSdkModule.kt
@@ -15,6 +15,10 @@ import com.tryhelium.paywall.core.HeliumEnvironment
 import com.tryhelium.paywall.core.event.HeliumEvent
 import com.tryhelium.paywall.core.event.HeliumEventDictionaryMapper
 import com.tryhelium.paywall.core.event.PaywallEventHandlers
+import com.tryhelium.paywall.core.event.PaywallSkipped
+import com.tryhelium.paywall.core.event.PaywallSkippedReason
+import com.tryhelium.paywall.core.event.PurchaseRestored
+import com.tryhelium.paywall.core.event.PurchaseSucceeded
 import com.tryhelium.paywall.core.HeliumUserTraits
 import com.tryhelium.paywall.core.HeliumUserTraits.Companion.create
 import com.tryhelium.paywall.core.HeliumPaywallTransactionStatus
@@ -57,6 +61,13 @@ private object NativeModuleManager {
   // SDK coroutine dispatcher). @Volatile ensures cross-thread visibility of the reference.
   @Volatile
   var currentModule: HeliumPaywallSdkModule? = null
+
+  // The most recent entitling event (purchase success/restore, or already-entitled skip),
+  // captured from the delegate event stream. The native Android SDK's onEntitled callback
+  // carries no event argument, so presentUpsell attaches this as the onEntitledEvent payload.
+  // Written from the SDK's event dispatch thread; read on the callback thread.
+  @Volatile
+  var lastEntitledEvent: Map<String, Any?>? = null
 
   // Guards the active purchase/restore continuations against cross-thread races between
   // the Expo module thread (handlePurchaseResult) and the Helium SDK coroutine dispatcher
@@ -276,6 +287,16 @@ class HeliumPaywallSdkModule : Module() {
         eventMap["buttonName"]?.let { eventMap["ctaName"] = it }
         applyEventFieldAliases(eventMap)
 
+        // Capture entitling events so presentUpsell can attach one to its onEntitledEvent
+        // payload — the native Android SDK's onEntitled callback carries no event argument.
+        when (event) {
+          is PurchaseSucceeded, is PurchaseRestored -> NativeModuleManager.lastEntitledEvent = eventMap
+          is PaywallSkipped -> if (event.skipReason == PaywallSkippedReason.AlreadyEntitled) {
+            NativeModuleManager.lastEntitledEvent = eventMap
+          }
+          else -> {}
+        }
+
         NativeModuleManager.safeSendEvent("onHeliumPaywallEvent", eventMap)
       }
 
@@ -381,6 +402,7 @@ class HeliumPaywallSdkModule : Module() {
     Function("presentUpsell") { trigger: String, customPaywallTraits: Map<String, Any>?, dontShowIfAlreadyEntitled: Boolean?, disableSystemBackNavigation: Boolean? ->
       NativeModuleManager.currentModule = this@HeliumPaywallSdkModule // extra redundancy to update to latest live module
       NativeModuleManager.flushEvents(this@HeliumPaywallSdkModule)
+      NativeModuleManager.lastEntitledEvent = null // don't let a previous presentation's event leak into this one
 
       // Convert custom paywall traits
       val convertedTraits = convertToHeliumUserTraits(customPaywallTraits)
@@ -408,7 +430,7 @@ class HeliumPaywallSdkModule : Module() {
         onEntitled = {
           NativeModuleManager.safeSendEvent(
             "onEntitledEvent",
-            emptyMap(),
+            NativeModuleManager.lastEntitledEvent ?: emptyMap(),
             this@HeliumPaywallSdkModule
           )
         },
@@ -556,6 +578,7 @@ class HeliumPaywallSdkModule : Module() {
       // Reset logger so initialize() can set up a fresh BridgingLogger
       Helium.config.logger = HeliumLogger.Stdout
       NativeModuleManager.clearPendingEvents()
+      NativeModuleManager.lastEntitledEvent = null
       try {
         suspendCancellableCoroutine<Unit> { continuation ->
           Helium.resetHelium(

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -100,8 +100,8 @@ export default function App() {
                   }
                 },
                 // dontShowIfAlreadyEntitled: true,
-                onEntitled: () => {
-                  console.log('onEntitled called!')
+                onEntitled: (event) => {
+                  console.log('onEntitled called!', event?.type, event?.productId)
                 },
                 onPaywallUnavailable: () => {
                   console.log('onPaywallUnavailable called!')

--- a/ios/HeliumPaywallSdkModule.swift
+++ b/ios/HeliumPaywallSdkModule.swift
@@ -278,8 +278,10 @@ public class HeliumPaywallSdkModule: Module {
                     NativeModuleManager.shared.safeSendEvent(eventName: "paywallEventHandlers", eventData: eventDict)
                 }
             ),
-            onEntitled: {
-                NativeModuleManager.shared.safeSendEvent(eventName: "onEntitledEvent", eventData: [:])
+            onEntitled: { entitledEvent in
+                var eventDict = entitledEvent.event.toDictionary()
+                applyEventFieldAliases(&eventDict)
+                NativeModuleManager.shared.safeSendEvent(eventName: "onEntitledEvent", eventData: eventDict)
             }
         ) { paywallNotShownReason in
             // nothing for now

--- a/src/HeliumPaywallSdk.types.ts
+++ b/src/HeliumPaywallSdk.types.ts
@@ -9,7 +9,7 @@ export type HeliumPaywallSdkModuleEvents = {
   onDelegateActionEvent: (params: DelegateActionEvent) => void;
   paywallEventHandlers: (params: HeliumPaywallEvent) => void;
   onHeliumLogEvent: (params: HeliumLogEvent) => void;
-  onEntitledEvent: () => void;
+  onEntitledEvent: (params?: PaywallEntitledEvent) => void;
 };
 
 /** A log event emitted by the Helium SDK. */
@@ -89,6 +89,18 @@ export type HeliumPaymentProcessor = 'appStore' | 'stripe' | 'paddle';
 
 /** Reason a paywall was skipped (not shown) for a trigger. */
 export type PaywallSkippedReason = 'targetingHoldout' | 'alreadyEntitled';
+
+/**
+ * The entitling event passed to `onEntitled`, identifying how the user became (or was found to be) entitled.
+ * - `purchaseSucceeded`: a new purchase completed successfully.
+ * - `purchaseRestored`: an existing entitlement was surfaced via restore.
+ * - `purchaseAlreadyEntitled`: a purchase attempt resolved to an entitlement the user already had. (iOS only)
+ * - `paywallSkipped`: the paywall was not shown because the user is already entitled
+ *   (requires `dontShowIfAlreadyEntitled`).
+ */
+export type PaywallEntitledEvent = HeliumPaywallEvent & {
+  type: 'purchaseSucceeded' | 'purchaseRestored' | 'purchaseAlreadyEntitled' | 'paywallSkipped';
+};
 
 /**
  * How an existing entitlement was surfaced on a `purchaseRestored` event.
@@ -245,11 +257,14 @@ export type PresentUpsellParams = {
   dontShowIfAlreadyEntitled?: boolean;
   /** Optional. Android only. If true, disables the system back button/gesture while the paywall is displayed. Defaults to false. */
   androidDisableSystemBackNavigation?: boolean;
-  /** Optional. Called upon purchase success or purchase restore.
-   * If you set `dontShowIfAlreadyEntitled` to true, this handler will also be called when paywall not shown
-   * to users who already have entitlement for a product in the paywall.
+  /** Optional. Called with the entitling event upon purchase success (`purchaseSucceeded`),
+   * purchase restore (`purchaseRestored`), or a purchase attempt resolving to an existing
+   * entitlement (`purchaseAlreadyEntitled`, iOS only) — in these cases it is called when the paywall closes.
+   * If you set `dontShowIfAlreadyEntitled` to true, this handler is also called immediately with a
+   * `paywallSkipped` event when the paywall is not shown to users who already have entitlement
+   * for a product in the paywall.
    */
-  onEntitled?: () => void;
+  onEntitled?: (event?: PaywallEntitledEvent) => void;
   /** Optional. Called if desired paywall and fallback paywall did not show for any reason.
    * This is uncommon, but best practice to handle it just in case.
    * See https://docs.tryhelium.com/guides/fallback-bundle */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   HeliumLogEvent,
   HeliumPaywallEvent,
   HeliumTransactionStatus,
-  NativeHeliumConfig, PaywallEventHandlers, PaywallInfo, PresentUpsellParams,
+  NativeHeliumConfig, PaywallEntitledEvent, PaywallEventHandlers, PaywallInfo, PresentUpsellParams,
   ResetHeliumOptions,
   WebCheckoutProcessor,
 } from "./HeliumPaywallSdk.types";
@@ -43,7 +43,7 @@ function addHeliumLogEventListener(listener: (event: HeliumLogEvent) => void): E
   return HeliumPaywallSdkModule.addListener('onHeliumLogEvent', listener);
 }
 
-function addEntitledEventListener(listener: () => void): EventSubscription {
+function addEntitledEventListener(listener: (event?: PaywallEntitledEvent) => void): EventSubscription {
   return HeliumPaywallSdkModule.addListener('onEntitledEvent', listener);
 }
 
@@ -154,8 +154,10 @@ function setupEventListeners(config: HeliumConfig) {
   });
 
   // Set up listener for onEntitled callback from native presentPaywall
-  addEntitledEventListener(() => {
-    presentOnEntitled?.();
+  addEntitledEventListener((event) => {
+    // Native sends an empty payload when the entitling event isn't available
+    const entitledEvent = event && event.type ? event : undefined;
+    presentOnEntitled?.(entitledEvent);
     presentOnEntitled = undefined;
   });
 }
@@ -258,7 +260,7 @@ export const initialize = async (config: HeliumConfig) => {
 
 let paywallEventHandlers: PaywallEventHandlers | undefined;
 let presentOnPaywallUnavailable: (() => void) | undefined;
-let presentOnEntitled: (() => void) | undefined;
+let presentOnEntitled: ((event?: PaywallEntitledEvent) => void) | undefined;
 export const presentUpsell = ({
                                 triggerName,
                                 eventHandlers,


### PR DESCRIPTION
## Summary

`presentUpsell`'s `onEntitled` callback now receives the entitling event as an optional argument, mirroring the native iOS SDK's `PaywallEntitledEvent` API ([HEL-6243](https://linear.app/tryhelium/issue/HEL-6243)):

```ts
onEntitled: (event) => {
  // event?.type: 'purchaseSucceeded' | 'purchaseRestored' | 'purchaseAlreadyEntitled' | 'paywallSkipped'
}
```

Backward compatible — existing no-arg `onEntitled` callbacks continue to work unchanged.

## Platform notes

- **iOS**: switches to the Helium 4.6.0 (already pinned) `onEntitled: ((PaywallEntitledEvent) -> Void)` overload and forwards the underlying event's dictionary in the `onEntitledEvent` payload.
- **Android**: the native SDK's `onEntitled` carries no event argument yet, so the module captures the last entitling event (`purchaseSucceeded`, `purchaseRestored`, or `paywallSkipped` with `skipReason: alreadyEntitled` — the skip event is guaranteed to fire before `onEntitled` per [HEL-5117](https://linear.app/tryhelium/issue/HEL-5117)) from the delegate event stream and attaches it to the `onEntitledEvent` payload. Cleared on each `presentUpsell` and on `resetHelium` so a stale event can't leak across presentations.
- The JS argument is optional (`event?: PaywallEntitledEvent`) since the payload can be unavailable (e.g. empty payload from an older native path).

## Testing

- `npm run build` (tsc) passes
- Android module compiles (`:expo-helium:compileDebugKotlin`)
- iOS dev pod builds against Helium 4.6.0 (`xcodebuild -target HeliumPaywallSdk`)

Closes [HEL-6403](https://linear.app/tryhelium/issue/HEL-6403/expo-onentitled-events-to-include-purchaserestorealready-entitled)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the purchase/entitlement callback path across iOS and Android bridging, though behavior stays backward compatible and Android relies on event ordering for the synthesized payload.
> 
> **Overview**
> **`presentUpsell`'s `onEntitled` now receives an optional `PaywallEntitledEvent`** describing how the user became entitled (`purchaseSucceeded`, `purchaseRestored`, `purchaseAlreadyEntitled` on iOS, or `paywallSkipped` when `dontShowIfAlreadyEntitled` skips the paywall). Existing no-arg handlers remain valid.
> 
> On **iOS**, the native Helium `onEntitled` payload is serialized and sent on `onEntitledEvent`. On **Android**, where native `onEntitled` has no event argument, the bridge stores the latest entitling event from the delegate stream and attaches it when `onEntitled` fires; that cache is cleared at each `presentUpsell` and on `resetHelium` to avoid stale data.
> 
> TypeScript adds `PaywallEntitledEvent` and wires the JS listener to treat an empty native payload as `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd596f4e2f37fae6f1165407702074ed4b8a7c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
